### PR TITLE
version 0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,260 @@ Python client for the ENTSO-E API (european network of transmission system opera
 
 Documentation of the API found on https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html
 
+## Installation
+`python3 -m pip install entsoe-py`
 
-### Notes
-When querying Day-Ahead prices, the country codes 'DE' and 'LU' are mapped to the 'DE-AT-LU' bidding zone
+## Usage
+The package comes with 2 clients:
+- [`EntsoeRawClient`](#EntsoeRawClient): Returns data in its raw format, usually XML or a ZIP-file containing XML's
+- [`EntsoePandasClient`](#EntsoePandasClient): Returns data parsed as a Pandas Series or DataFrame
+### <a name="EntsoeRawClient"></a>EntsoeRawClient
+```python
+from entsoe import EntsoeRawClient
+import pandas as pd
+
+client = EntsoeRawClient(api_key=<YOUR API KEY>)
+
+start = pd.Timestamp('20171201', tz='Europe/Brussels')
+end = pd.Timestamp('20180101', tz='Europe/Brussels')
+country_code = 'BE'  # Belgium
+
+# methods that return XML
+client.query_day_ahead_prices(country_code, start, end)
+client.query_load(country_code, start, end)
+client.query_generation_forecast(country_code, start, end, psr_type=None)
+client.query_generation(country_code, start, end, psr_type=None)
+client.query_installed_generation_capacity(country_code, start, end, psr_type=None)
+client.query_crossborder_flows(country_code_from, country_code_to, start, end)
+client.query_imbalance_prices(country_code, start, end, psr_type=None)
+
+# methods that return ZIP
+client.query_unavailability_of_generation_units(country_code, start, end, docstatus=None)
+client.query_withdrawn_unavailability_of_generation_units(country_code, start, end)
+```
+#### Dump result to file
+```python
+xml_string = client.query_day_ahead_prices(country_code, start, end)
+with open('outfile.xml', 'w') as f:
+    f.write(xml_string)
+
+zip_bytes = client.query_unavailability_of_generation_units(country_code, start, end)
+with open('outfile.zip', 'wb') as f:
+    f.write(zip_bytes)
+```
+#### Making another request
+Is the API-call you want not in the list, you can lookup the parameters yourself in the API documentation?
+```python
+params = {
+    'documentType': 'A44',
+    'in_Domain': '10YBE----------2',
+    'out_Domain': '10YBE----------2'
+}
+response = client.base_request(params=params, start=start, end=end)
+print(response.text)
+```
+
+### <a name="EntsoePandasClient"></a>EntsoePandasClient
+The Pandas Client works similar to the Raw Client, with extras:
+- Time periods that span more than 1 year are automatically dealt with
+- Requests of large numbers of files are split over multiple API calls
+```python
+from entsoe import EntsoePandasClient
+import pandas as pd
+
+client = EntsoePandasClient(api_key=<YOUR API KEY>)
+
+start = pd.Timestamp('20171201', tz='Europe/Brussels')
+end = pd.Timestamp('20180101', tz='Europe/Brussels')
+country_code = 'BE'  # Belgium
+
+# methods that return Pandas Series
+client.query_day_ahead_prices(country_code, start, end)
+client.query_load(country_code, start, end)
+
+# methods that return Pandas DataFrames
+client.query_generation_forecast(country_code, start, end, psr_type=None)
+client.query_generation(country_code, start, end, psr_type=None)
+client.query_installed_generation_capacity(country_code, start, end, psr_type=None)
+client.query_crossborder_flows(country_code_from, country_code_to, start, end)
+client.query_imbalance_prices(country_code, start, end, psr_type=None)
+client.query_unavailability_of_generation_units(country_code, start, end, docstatus=None)
+client.query_withdrawn_unavailability_of_generation_units(country_code, start, end)
+```
+#### Dump result to file
+See a list of all IO-methods on https://pandas.pydata.org/pandas-docs/stable/io.html
+```python
+ts = client.query_day_ahead_prices(country_code, start, end)
+ts.to_csv('outfile.csv')
+```
+
+### Mappings
+These lists are always evolving, so let us know if something's inaccurate!
+#### Domains
+```python
+DOMAIN_MAPPINGS = {
+    'AL': '10YAL-KESH-----5',
+    'AT': '10YAT-APG------L',
+    'BA': '10YBA-JPCC-----D',
+    'BE': '10YBE----------2',
+    'BG': '10YCA-BULGARIA-R',
+    'BY': '10Y1001A1001A51S',
+    'CH': '10YCH-SWISSGRIDZ',
+    'CZ': '10YCZ-CEPS-----N',
+    'DE': '10Y1001A1001A83F',
+    'DK': '10Y1001A1001A65H',
+    'EE': '10Y1001A1001A39I',
+    'ES': '10YES-REE------0',
+    'FI': '10YFI-1--------U',
+    'FR': '10YFR-RTE------C',
+    'GB': '10YGB----------A',
+    'GB-NIR': '10Y1001A1001A016',
+    'GR': '10YGR-HTSO-----Y',
+    'HR': '10YHR-HEP------M',
+    'HU': '10YHU-MAVIR----U',
+    'IE': '10YIE-1001A00010',
+    'IT': '10YIT-GRTN-----B',
+    'LT': '10YLT-1001A0008Q',
+    'LU': '10YLU-CEGEDEL-NQ',
+    'LV': '10YLV-1001A00074',
+    # 'MD': 'MD',
+    'ME': '10YCS-CG-TSO---S',
+    'MK': '10YMK-MEPSO----8',
+    'MT': '10Y1001A1001A93C',
+    'NL': '10YNL----------L',
+    'NO': '10YNO-0--------C',
+    'PL': '10YPL-AREA-----S',
+    'PT': '10YPT-REN------W',
+    'RO': '10YRO-TEL------P',
+    'RS': '10YCS-SERBIATSOV',
+    'RU': '10Y1001A1001A49F',
+    'RU-KGD': '10Y1001A1001A50U',
+    'SE': '10YSE-1--------K',
+    'SI': '10YSI-ELES-----O',
+    'SK': '10YSK-SEPS-----K',
+    'TR': '10YTR-TEIAS----W',
+    'UA': '10YUA-WEPS-----0',
+    'DE-AT-LU': '10Y1001A1001A63L',
+}
+```
+### Bidding Zones
+```python
+BIDDING_ZONES = DOMAIN_MAPPINGS.copy()
+BIDDING_ZONES.update({
+    'DE': '10Y1001A1001A63L',  # DE-AT-LU
+    'LU': '10Y1001A1001A63L',  # DE-AT-LU
+    'IT-NORD': '10Y1001A1001A73I',
+    'IT-CNOR': '10Y1001A1001A70O',
+    'IT-CSUD': '10Y1001A1001A71M',
+    'IT-SUD': '10Y1001A1001A788',
+    'IT-FOGN': '10Y1001A1001A72K',
+    'IT-ROSN': '10Y1001A1001A77A',
+    'IT-BRNN': '10Y1001A1001A699',
+    'IT-PRGP': '10Y1001A1001A76C',
+    'IT-SARD': '10Y1001A1001A74G',
+    'IT-SICI': '10Y1001A1001A75E'
+})
+```
+#### PSR-type
+```python
+PSRTYPE_MAPPINGS = {
+    'A03': 'Mixed',
+    'A04': 'Generation',
+    'A05': 'Load',
+    'B01': 'Biomass',
+    'B02': 'Fossil Brown coal/Lignite',
+    'B03': 'Fossil Coal-derived gas',
+    'B04': 'Fossil Gas',
+    'B05': 'Fossil Hard coal',
+    'B06': 'Fossil Oil',
+    'B07': 'Fossil Oil shale',
+    'B08': 'Fossil Peat',
+    'B09': 'Geothermal',
+    'B10': 'Hydro Pumped Storage',
+    'B11': 'Hydro Run-of-river and poundage',
+    'B12': 'Hydro Water Reservoir',
+    'B13': 'Marine',
+    'B14': 'Nuclear',
+    'B15': 'Other renewable',
+    'B16': 'Solar',
+    'B17': 'Waste',
+    'B18': 'Wind Offshore',
+    'B19': 'Wind Onshore',
+    'B20': 'Other',
+    'B21': 'AC Link',
+    'B22': 'DC Link',
+    'B23': 'Substation',
+    'B24': 'Transformer'}
+```
+#### Docstatus
+```python
+DOCSTATUS = {
+    'A05': 'Active',
+    'A09': 'Cancelled',
+    'A13': 'Withdrawn'
+}
+```
+#### BSN-type
+```python
+BSNTYPE = {'A29': 'Already allocated capacity (AAC)',
+           'A43': 'Requested capacity (without price)',
+           'A46': 'System Operator redispatching',
+           'A53': 'Planned maintenance',
+           'A54': 'Unplanned outage',
+           'A85': 'Internal redispatch',
+           'A95': 'Frequency containment reserve',
+           'A96': 'Automatic frequency restoration reserve',
+           'A97': 'Manual frequency restoration reserve',
+           'A98': 'Replacement reserve',
+           'B01': 'Interconnector network evolution',
+           'B02': 'Interconnector network dismantling',
+           'B03': 'Counter trade',
+           'B04': 'Congestion costs',
+           'B05': 'Capacity allocated (including price)',
+           'B07': 'Auction revenue',
+           'B08': 'Total nominated capacity',
+           'B09': 'Net position',
+           'B10': 'Congestion income',
+           'B11': 'Production unit'}
+```
+#### DocumentType
+```python
+DOCUMENTTYPE = {'A09': 'Finalised schedule',
+                'A11': 'Aggregated energy data report',
+                'A25': 'Allocation result document',
+                'A26': 'Capacity document',
+                'A31': 'Agreed capacity',
+                'A44': 'Price Document',
+                'A61': 'Estimated Net Transfer Capacity',
+                'A63': 'Redispatch notice',
+                'A65': 'System total load',
+                'A68': 'Installed generation per type',
+                'A69': 'Wind and solar forecast',
+                'A70': 'Load forecast margin',
+                'A71': 'Generation forecast',
+                'A72': 'Reservoir filling information',
+                'A73': 'Actual generation',
+                'A74': 'Wind and solar generation',
+                'A75': 'Actual generation per type',
+                'A76': 'Load unavailability',
+                'A77': 'Production unavailability',
+                'A78': 'Transmission unavailability',
+                'A79': 'Offshore grid infrastructure unavailability',
+                'A80': 'Generation unavailability',
+                'A81': 'Contracted reserves',
+                'A82': 'Accepted offers',
+                'A83': 'Activated balancing quantities',
+                'A84': 'Activated balancing prices',
+                'A85': 'Imbalance prices',
+                'A86': 'Imbalance volume',
+                'A87': 'Financial situation',
+                'A88': 'Cross border balancing',
+                'A89': 'Contracted reserve prices',
+                'A90': 'Interconnection network expansion',
+                'A91': 'Counter trade notice',
+                'A92': 'Congestion costs',
+                'A93': 'DC link capacity',
+                'A94': 'Non EU allocations',
+                'A95': 'Configuration document',
+                'B11': 'Flow-based allocations'}
+```

--- a/entsoe/__init__.py
+++ b/entsoe/__init__.py
@@ -1,1 +1,1 @@
-from .entsoe import Entsoe, __version__, PSRTYPE_MAPPINGS
+from .entsoe import EntsoeRawClient, EntsoePandasClient, __version__

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -579,3 +579,20 @@ class EntsoePandasClient(EntsoeRawClient):
             docstatus=docstatus)
         df = parse_unavailabilities(content)
         return df
+
+    def query_withdrawn_unavailability_of_generation_units(
+            self, country_code, start, end):
+        """
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+
+        Returns
+        -------
+        pd.DataFrame
+        """
+        df = self.query_unavailability_of_generation_units(
+            country_code=country_code, start=start, end=end, docstatus='A13')
+        return df

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1,29 +1,51 @@
+from functools import wraps
+from socket import gaierror
+from time import sleep
+
+import pandas as pd
 import pytz
 import requests
 from bs4 import BeautifulSoup
-from time import sleep
-from socket import gaierror
-import pandas as pd
+
+from .exceptions import NoMatchingDataError, PaginationError
 from .mappings import DOMAIN_MAPPINGS, BIDDING_ZONES, TIMEZONE_MAPPINGS
+from .misc import year_blocks
+from .parsers import parse_prices, parse_loads, parse_generation, \
+    parse_crossborder_flows, parse_imbalance_prices, parse_unavailabilities
 
 __title__ = "entsoe-py"
-__version__ = "0.1.18"
+__version__ = "0.2.0"
 __author__ = "EnergieID.be"
 __license__ = "MIT"
 
 URL = 'https://transparency.entsoe.eu/api'
 
+def retry(func):
+    """Catches connection errors, waits and retries"""
+    @wraps(func)
+    def retry_wrapper(*args, **kwargs):
+        self = args[0]
+        error = None
+        for _ in range(self.retry_count):
+            try:
+                result = func(*args, **kwargs)
+            except (requests.ConnectionError, gaierror) as e:
+                error = e
+                print("Connection Error, retrying in {} seconds".format(self.retry_delay))
+                sleep(self.retry_delay)
+                continue
+            else:
+                return result
+        else:
+            raise error
+    return retry_wrapper
 
-class PaginationError(Exception):
-    pass
 
-
-class NoMatchingDataError(Exception):
-    pass
-
-
-class Entsoe:
+class EntsoeRawClient:
     """
+    Client to perform API calls and return the raw responses
+    API-documentation: https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_request_methods
+
     Attributions: Parts of the code for parsing Entsoe responses were copied
     from https://github.com/tmrowco/electricitymap
     """
@@ -35,9 +57,12 @@ class Entsoe:
         ----------
         api_key : str
         session : requests.Session
+        retry_count : int
+            number of times to retry the call if the connection fails
+        retry_delay: int
+            amount of seconds to wait between retries
         proxies : dict
             requests proxies
-        
         """
         if api_key is None:
             raise TypeError("API key cannot be None")
@@ -49,6 +74,7 @@ class Entsoe:
         self.retry_count = retry_count
         self.retry_delay = retry_delay
 
+    @retry
     def base_request(self, params, start, end):
         """
         Parameters
@@ -71,39 +97,25 @@ class Entsoe:
         }
         params.update(base_params)
 
-        error = None
-        for _ in range(self.retry_count):
-            try:
-                response = self.session.get(url=URL, params=params,
-                                            proxies=self.proxies)
-            except (requests.ConnectionError, gaierror) as e:
-                error = e
-                print("Connection Error, retrying in {} seconds".format(self.retry_delay))
-                sleep(self.retry_delay)
-                continue
-
-            try:
-                response.raise_for_status()
-            except requests.HTTPError as e:
-                error = e
-                soup = BeautifulSoup(response.text, 'html.parser')
-                text = soup.find_all('text')
-                if len(text):
-                    error_text = soup.find('text').text
-                    if 'No matching data found' in error_text:
-                        print(f"No matching data found.")
-                        return
-                    if 'amount of requested data exceeds allowed limit' in error_text:
-                        requested = error_text.split(' ')[-2]
-                        print(
-                            f"The API is limited to 200 elements per request. This query requested for {requested} documents and cannot be fulfilled as is.")
-                        raise PaginationError
-                print("HTTP Error, retrying in {} seconds".format(self.retry_delay))
-                sleep(self.retry_delay)
-            else:
-                return response
+        response = self.session.get(url=URL, params=params,
+                                    proxies=self.proxies)
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            soup = BeautifulSoup(response.text, 'html.parser')
+            text = soup.find_all('text')
+            if len(text):
+                error_text = soup.find('text').text
+                if 'No matching data found' in error_text:
+                    raise NoMatchingDataError
+                elif 'amount of requested data exceeds allowed limit' in error_text:
+                    requested = error_text.split(' ')[-2]
+                    raise PaginationError(
+                        f"The API is limited to 200 elements per request. This query requested for {requested} documents and cannot be fulfilled as is.")
+            raise e
         else:
-            raise error
+            return response
+
 
     @staticmethod
     def _datetime_to_str(dtm):
@@ -127,21 +139,17 @@ class Entsoe:
         ret_str = dtm.strftime(fmt)
         return ret_str
 
-    def query_price(self, country_code, start, end, as_series=False):
+    def query_day_ahead_prices(self, country_code, start, end):
         """
         Parameters
         ----------
         country_code : str
         start : pd.Timestamp
         end : pd.Timestamp
-        as_series : bool
-            Default False
-            If True: Return the response as a Pandas Series
-            If False: Return the response as raw XML
 
         Returns
         -------
-        str | pd.Series
+        str
         """
         domain = BIDDING_ZONES[country_code]
         params = {
@@ -150,22 +158,253 @@ class Entsoe:
             'out_Domain': domain
         }
         response = self.base_request(params=params, start=start, end=end)
-        if response is None:
-            return None
-        if not as_series:
-            return response.text
-        else:
-            from . import parsers
-            series = parsers.parse_prices(response.text)
-            series = series.tz_convert(TIMEZONE_MAPPINGS[country_code])
-            return series
+        return response.text
 
-    def query_price_series(self, country_code, start, end):
+    def query_load(self, country_code, start, end):
         """
-        Query Day Ahead prices as Pandas Series
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
 
-        This method has the added benefit that you can query over periods larger than one year
+        Returns
+        -------
+        str
+        """
+        domain = BIDDING_ZONES[country_code]
+        params = {
+            'documentType': 'A65',
+            'processType': 'A16',
+            'outBiddingZone_Domain': domain,
+            'out_Domain': domain
+        }
+        response = self.base_request(params=params, start=start, end=end)
+        return response.text
 
+    def query_generation_forecast(self, country_code, start, end, psr_type=None, lookup_bzones=False):
+        """
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+        psr_type : str
+            filter on a single psr type
+        lookup_bzones : bool
+            if True, country_code is expected to be a bidding zone
+
+        Returns
+        -------
+        str
+        """
+        if not lookup_bzones:
+            domain = DOMAIN_MAPPINGS[country_code]
+        else:
+            domain = BIDDING_ZONES[country_code]
+
+        params = {
+            'documentType': 'A69',
+            'processType': 'A01',
+            'in_Domain': domain,
+        }
+        if psr_type:
+            params.update({'psrType': psr_type})
+
+        response = self.base_request(params=params, start=start, end=end)
+        return response.text
+
+    def query_generation(self, country_code, start, end, psr_type=None, lookup_bzones=False):
+        """
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+        psr_type : str
+            filter on a single psr type
+        lookup_bzones : bool
+            if True, country_code is expected to be a bidding zone
+
+        Returns
+        -------
+        str
+        """
+        if not lookup_bzones:
+            domain = DOMAIN_MAPPINGS[country_code]
+        else:
+            domain = BIDDING_ZONES[country_code]
+
+        params = {
+            'documentType': 'A75',
+            'processType': 'A16',
+            'in_Domain': domain,
+        }
+        if psr_type:
+            params.update({'psrType': psr_type})
+
+        response = self.base_request(params=params, start=start, end=end)
+        return response.text
+
+    def query_installed_generation_capacity(self, country_code, start, end, psr_type=None):
+        """
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+        psr_type : str
+            filter query for a specific psr type
+
+        Returns
+        -------
+        str
+        """
+        domain = DOMAIN_MAPPINGS[country_code]
+        params = {
+            'documentType': 'A68',
+            'processType': 'A33',
+            'in_Domain': domain,
+        }
+        if psr_type:
+            params.update({'psrType': psr_type})
+
+        response = self.base_request(params=params, start=start, end=end)
+        return response.text
+
+    def query_crossborder_flows(self, country_code_from, country_code_to, start, end):
+        """
+        Parameters
+        ----------
+        country_code_from : str
+        country_code_to : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+
+        Returns
+        -------
+        str
+        """
+        domain_in = DOMAIN_MAPPINGS[country_code_to]
+        domain_out = DOMAIN_MAPPINGS[country_code_from]
+        params = {
+            'documentType': 'A11',
+            'in_Domain': domain_in,
+            'out_Domain': domain_out
+        }
+        response = self.base_request(params=params, start=start, end=end)
+        return response.text
+
+    def query_imbalance_prices(self, country_code, start, end, psr_type=None):
+        """
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+        psr_type : str
+            filter query for a specific psr type
+
+        Returns
+        -------
+        str
+        """
+        domain = DOMAIN_MAPPINGS[country_code]
+        params = {
+            'documentType': 'A85',
+            'controlArea_Domain': domain,
+        }
+        if psr_type:
+            params.update({'psrType': psr_type})
+        response = self.base_request(params=params, start=start, end=end)
+        return response.text
+
+    def query_unavailability_of_generation_units(self, country_code, start, end,
+                                                 docstatus=None) -> bytes:
+        """
+        This endpoint serves ZIP files.
+        The query is limited to 200 items per request.
+
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+        docstatus : str, optional
+
+        Returns
+        -------
+        bytes
+        """
+        domain = DOMAIN_MAPPINGS[country_code]
+        params = {
+            'documentType': 'A77',
+            'biddingZone_domain': domain
+            # ,'businessType': 'A53 (unplanned) | A54 (planned)'
+        }
+
+        if docstatus:
+            params['docStatus'] = docstatus
+
+        response = self.base_request(params=params, start=start, end=end)
+
+        return response.content
+
+    def query_withdrawn_unavailability_of_generation_units(
+            self, country_code, start, end):
+        """
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+        """
+        content = self.query_unavailability_of_generation_units(
+            country_code=country_code, start=start, end=end, docstatus='A13')
+        return content
+
+
+def paginated(func):
+    """Catches a PaginationError, splits the requested period in two and tries
+    again. Finally it concatenates the results"""
+
+    @wraps(func)
+    def pagination_wrapper(*args, **kwargs):
+        try:
+            df = func(*args, **kwargs)
+        except PaginationError:
+            start = kwargs.pop('start')
+            end = kwargs.pop('end')
+            pivot = start + (end - start) / 2
+            df1 = pagination_wrapper(*args, start=start, end=pivot, **kwargs)
+            df2 = pagination_wrapper(*args, start=pivot, end=end, **kwargs)
+            df = pd.concat([df1, df2])
+        return df
+
+    return pagination_wrapper
+
+
+def year_limited(func):
+    """Deals with calls where you cannot query more than a year, by splitting
+    the call up in blocks per year"""
+
+    @wraps(func)
+    def year_wrapper(*args, **kwargs):
+        start = kwargs.pop('start')
+        end = kwargs.pop('end')
+        blocks = year_blocks(start, end)
+        frames = [func(*args, start=_start, end=_end, **kwargs) for _start, _end
+                  in blocks]
+        df = pd.concat(frames)
+        return df
+
+    return year_wrapper
+
+
+class EntsoePandasClient(EntsoeRawClient):
+    @year_limited
+    def query_day_ahead_prices(self, country_code, start, end) -> pd.Series:
+        """
         Parameters
         ----------
         country_code : str
@@ -176,184 +415,106 @@ class Entsoe:
         -------
         pd.Series
         """
-        from .misc import year_blocks
-        import pandas as pd
+        text = super(EntsoePandasClient, self).query_day_ahead_prices(
+            country_code=country_code, start=start, end=end)
+        series = parse_prices(text)
+        series = series.tz_convert(TIMEZONE_MAPPINGS[country_code])
+        return series
 
-        series = (self.query_price(country_code=country_code, start=_start, end=_end, as_series=True) for _start, _end in year_blocks(start, end))
-        ts = pd.concat(series)
-        return ts
-
-    def query_load(self, country_code, start, end, as_series=False):
+    @year_limited
+    def query_load(self, country_code, start, end) -> pd.DataFrame:
         """
         Parameters
         ----------
         country_code : str
         start : pd.Timestamp
         end : pd.Timestamp
-        as_series : bool
-            Default False
-            If True: Return the response as a Pandas Series
-            If False: Return the response as raw XML
 
         Returns
         -------
-        str | pd.Series
+        pd.DataFrame
         """
-        domain = BIDDING_ZONES[country_code]
-        params = {
-            'documentType': 'A65',
-            'processType': 'A16',
-            'outBiddingZone_Domain': domain,
-            'out_Domain': domain
-        }
-        response = self.base_request(params=params, start=start, end=end)
-        if response is None:
-            return None
-        if not as_series:
-            return response.text
-        else:
-            from . import parsers
-            series = parsers.parse_loads(response.text)
-            series = series.tz_convert(TIMEZONE_MAPPINGS[country_code])
-            return series
+        text = super(EntsoePandasClient, self).query_load(
+            country_code=country_code, start=start, end=end)
+        series = parse_loads(text)
+        series = series.tz_convert(TIMEZONE_MAPPINGS[country_code])
+        return series
 
-    def query_generation_forecast(self, country_code, start, end, as_dataframe=False, psr_type=None, squeeze=False, lookup_bzones=False):
+    @year_limited
+    def query_generation_forecast(self, country_code, start, end, psr_type=None,
+                                  lookup_bzones=False):
         """
         Parameters
         ----------
         country_code : str
         start : pd.Timestamp
         end : pd.Timestamp
-        as_dataframe : bool
-            Default False
-            If True: Return the response as a Pandas DataFrame
-            If False: Return the response as raw XML
         psr_type : str
             filter on a single psr type
-        squeeze : bool
-            If a single column is requested, return it as a Series instead of a DataFrame
-            If there is just a single value, return it as a float
         lookup_bzones : bool
             if True, country_code is expected to be a bidding zone
 
         Returns
         -------
-        str | pd.DataFrame
+        pd.DataFrame
         """
-        if not lookup_bzones:
-            domain = DOMAIN_MAPPINGS[country_code]
-        else:
-            domain = BIDDING_ZONES[country_code]
-        params = {
-            'documentType': 'A69',
-            'processType': 'A01',
-            'in_Domain': domain,
-        }
-        if psr_type:
-            params.update({'psrType': psr_type})
-        response = self.base_request(params=params, start=start, end=end)
-        if response is None:
-            return None
-        if not as_dataframe:
-            return response.text
-        else:
-            from . import parsers
-            df = parsers.parse_generation(response.text)
-            df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
-            if squeeze:
-                df = df.squeeze()
-            return df
+        text = super(EntsoePandasClient, self).query_generation_forecast(
+            country_code=country_code, start=start, end=end, psr_type=psr_type,
+            lookup_bzones=lookup_bzones)
+        df = parse_generation(text)
+        df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
+        return df
 
-    def query_generation(self, country_code, start, end, as_dataframe=False, psr_type=None, squeeze=False, lookup_bzones=False):
+    @year_limited
+    def query_generation(self, country_code, start, end, psr_type=None,
+                         lookup_bzones=False):
         """
         Parameters
         ----------
         country_code : str
         start : pd.Timestamp
         end : pd.Timestamp
-        as_dataframe : bool
-            Default False
-            If True: Return the response as a Pandas DataFrame
-            If False: Return the response as raw XML
         psr_type : str
             filter on a single psr type
-        squeeze : bool
-            If a single column is requested, return it as a Series instead of a DataFrame
-            If there is just a single value, return it as a float
         lookup_bzones : bool
             if True, country_code is expected to be a bidding zone
 
         Returns
         -------
-        str | pd.DataFrame
+        pd.DataFrame
         """
-        if not lookup_bzones:
-            domain = DOMAIN_MAPPINGS[country_code]
-        else:
-            domain = BIDDING_ZONES[country_code]
-        params = {
-            'documentType': 'A75',
-            'processType': 'A16',
-            'in_Domain': domain,
-        }
-        if psr_type:
-            params.update({'psrType': psr_type})
-        response = self.base_request(params=params, start=start, end=end)
-        if response is None:
-            return None
-        if not as_dataframe:
-            return response.text
-        else:
-            from . import parsers
-            df = parsers.parse_generation(response.text)
-            df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
-            if squeeze:
-                df = df.squeeze()
-            return df
+        text = super(EntsoePandasClient, self).query_generation(
+            country_code=country_code, start=start, end=end, psr_type=psr_type,
+            lookup_bzones=lookup_bzones)
+        df = parse_generation(text)
+        df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
+        return df
 
-    def query_installed_generation_capacity(self, country_code, start, end, as_dataframe=False, psr_type=None, squeeze=False):
+    @year_limited
+    def query_installed_generation_capacity(self, country_code, start, end,
+                                            psr_type=None):
         """
         Parameters
         ----------
         country_code : str
         start : pd.Timestamp
         end : pd.Timestamp
-        as_dataframe : bool
-            Default False
-            If True: Return the response as a Pandas DataFrame
-            If False: Return the response as raw XML
         psr_type : str
             filter query for a specific psr type
-        squeeze : bool
-            If a single column is requested, return it as a Series instead of a DataFrame
-            If there is just a single value, return it as a float
 
         Returns
         -------
-        str | pd.DataFrame
+        pd.DataFrame
         """
-        domain = DOMAIN_MAPPINGS[country_code]
-        params = {
-            'documentType': 'A68',
-            'processType': 'A33',
-            'in_Domain': domain,
-        }
-        if psr_type:
-            params.update({'psrType': psr_type})
-        response = self.base_request(params=params, start=start, end=end)
-        if response is None:
-            return None
-        if not as_dataframe:
-            return response.text
-        else:
-            from . import parsers
-            df = parsers.parse_generation(response.text)
-            df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
-            if squeeze:
-                df = df.squeeze()
-            return df
-        
-    def query_crossborder_flows(self, country_code_from, country_code_to, start, end, as_series=False):
+        text = super(
+            EntsoePandasClient, self).query_installed_generation_capacity(
+            country_code=country_code, start=start, end=end, psr_type=psr_type)
+        df = parse_generation(text)
+        df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
+        return df
+
+    @year_limited
+    def query_crossborder_flows(self, country_code_from, country_code_to, start, end):
         """
         Note: Result will be in the timezone of the origin country
 
@@ -363,93 +524,58 @@ class Entsoe:
         country_code_to : str
         start : pd.Timestamp
         end : pd.Timestamp
-        as_series : bool
-            Default False
-            If True: Return the response as a Pandas Series
-            If False: Return the response as raw XML
 
         Returns
         -------
-        str | pd.DataFrame
+        pd.Series
         """
-        domain_in = DOMAIN_MAPPINGS[country_code_to]
-        domain_out = DOMAIN_MAPPINGS[country_code_from]
-        params = {
-            'documentType': 'A11',
-            'in_Domain': domain_in,
-            'out_Domain': domain_out
-        }
-        response = self.base_request(params=params, start=start, end=end)
-        if response is None:
-            return None
-        if not as_series:
-            return response.text
-        else:
-            from . import parsers
-            ts = parsers.parse_crossborder_flows(response.text)
-            ts = ts.tz_convert(TIMEZONE_MAPPINGS[country_code_from])
-            return ts
+        text = super(EntsoePandasClient, self).query_crossborder_flows(
+            country_code_from=country_code_from,
+            country_code_to=country_code_to, start=start, end=end)
+        ts = parse_crossborder_flows(text)
+        ts = ts.tz_convert(TIMEZONE_MAPPINGS[country_code_from])
+        return ts
 
-    def query_imbalance_prices(self, country_code, start, end, as_dataframe=False, psr_type=None):
+    @year_limited
+    def query_imbalance_prices(self, country_code, start, end, psr_type=None):
         """
-
         Parameters
         ----------
         country_code : str
         start : pd.Timestamp
         end : pd.Timestamp
-        as_dataframe : bool
+        psr_type : str
+            filter query for a specific psr type
 
         Returns
         -------
-        str \
+        pd.DataFrame
         """
-        domain = DOMAIN_MAPPINGS[country_code]
-        params = {
-            'documentType': 'A85',
-            'controlArea_Domain': domain,
-        }
-        if psr_type:
-            params.update({'psrType': psr_type})
-        response = self.base_request(params=params, start=start, end=end)
-        if response is None:
-            return None
-        if not as_dataframe:
-            return response.text
-        else:
-            from . import parsers
-            df = parsers.parse_imbalance_prices(response.text)
-            df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
-            return df
+        text = super(EntsoePandasClient, self).query_imbalance_prices(
+            country_code=country_code, start=start, end=end, psr_type=psr_type)
+        df = parse_imbalance_prices(text)
+        df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
+        return df
 
-    def query_unavailability_of_production_units(self, country_code: str, start: pd.Timestamp, end: pd.Timestamp, docstatus=None) -> pd.DataFrame:
+    @year_limited
+    @paginated
+    def query_unavailability_of_generation_units(self, country_code, start, end,
+                                                 docstatus=None):
         """
-        This endpoint serves ZIP files.
-        The query is limited to 200 items per request.
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+        docstatus : str, optional
+
+        Returns
+        -------
+        pd.DataFrame
         """
-        domain = DOMAIN_MAPPINGS[country_code]
-        params = {
-            'documentType': 'A77',
-            'biddingZone_domain': domain
-            #,'businessType': 'A53 (unplanned) | A54 (planned)'
-        }
-
-        withdrawn = None
-        if docstatus:
-            params['docStatus'] = docstatus
-        else:
-            withdrawn = self.query_unavailability_of_production_units(
-                country_code=country_code, docstatus='A13', start=start, end=end)  # withdrawn unavailabilities
-
-        try:
-            response = self.base_request(params=params, start=start, end=end)
-        except PaginationError:
-            print("Too many elements requested, going to split the interval in half.")
-            pivot = start + (end - start) / 2
-            return pd.concat([self.query_unavailability_of_production_units(country_code=country_code, docstatus=docstatus, start=start, end=pivot), self.query_unavailability_of_production_units(country_code=country_code, docstatus=docstatus, start=pivot, end=end)])
-        if response is None:
-            return pd.DataFrame()
-        else:
-            from . import parsers
-            df = parsers.parse_unavailabilities(response.content)
-            return pd.concat([df, withdrawn])
+        content = super(EntsoePandasClient,
+                        self).query_unavailability_of_generation_units(
+            country_code=country_code, start=start, end=end,
+            docstatus=docstatus)
+        df = parse_unavailabilities(content)
+        return df

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -422,7 +422,7 @@ class EntsoePandasClient(EntsoeRawClient):
         return series
 
     @year_limited
-    def query_load(self, country_code, start, end) -> pd.DataFrame:
+    def query_load(self, country_code, start, end) -> pd.Series:
         """
         Parameters
         ----------
@@ -432,7 +432,7 @@ class EntsoePandasClient(EntsoeRawClient):
 
         Returns
         -------
-        pd.DataFrame
+        pd.Series
         """
         text = super(EntsoePandasClient, self).query_load(
             country_code=country_code, start=start, end=end)
@@ -578,6 +578,9 @@ class EntsoePandasClient(EntsoeRawClient):
             country_code=country_code, start=start, end=end,
             docstatus=docstatus)
         df = parse_unavailabilities(content)
+        df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
+        df['start'] = df['start'].apply(lambda x: x.tz_convert(TIMEZONE_MAPPINGS[country_code]))
+        df['end'] = df['end'].apply(lambda x: x.tz_convert(TIMEZONE_MAPPINGS[country_code]))
         return df
 
     def query_withdrawn_unavailability_of_generation_units(

--- a/entsoe/exceptions.py
+++ b/entsoe/exceptions.py
@@ -1,0 +1,6 @@
+class PaginationError(Exception):
+    pass
+
+
+class NoMatchingDataError(Exception):
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 pytz
 beautifulsoup4
+pandas

--- a/setup.py
+++ b/setup.py
@@ -54,15 +54,8 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.7'
     ],
 
     keywords='ENTSO-E data api energy',
@@ -77,7 +70,7 @@ setup(
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed.
-    install_requires=['requests', 'pytz', 'beautifulsoup4'],
+    install_requires=['requests', 'pytz', 'beautifulsoup4', 'pandas'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,107 @@
+import unittest
+
+import pandas as pd
+from bs4 import BeautifulSoup
+
+from entsoe import EntsoeRawClient, EntsoePandasClient
+from entsoe.exceptions import NoMatchingDataError
+from settings import api_key
+
+class EntsoeRawClientTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.client = EntsoeRawClient(api_key=api_key)
+        cls.start = pd.Timestamp('20180101', tz='Europe/Brussels')
+        cls.end = pd.Timestamp('20180107', tz='Europe/Brussels')
+        cls.country_code = 'BE'
+
+    def test_datetime_to_str(self):
+        start_str = self.client._datetime_to_str(dtm=self.start)
+        self.assertIsInstance(start_str, str)
+        self.assertEqual(start_str, '201712312300')
+
+    def test_basic_queries(self):
+        queries = [
+            self.client.query_day_ahead_prices,
+            self.client.query_load,
+            self.client.query_generation_forecast,
+            self.client.query_generation,
+            self.client.query_installed_generation_capacity,
+            self.client.query_imbalance_prices
+        ]
+        for query in queries:
+            text = query(country_code=self.country_code, start=self.start,
+                         end=self.end)
+            self.assertIsInstance(text, str)
+            try:
+                BeautifulSoup(text, 'html.parser')
+            except Exception as e:
+                self.fail(f'Parsing of response failed with exception: {e}')
+
+    def query_crossborder_flows(self):
+        text = self.client.query_crossborder_flows(
+            country_code_from='BE', country_code_to='NL', start=self.start,
+            end=self.end)
+        self.assertIsInstance(text, str)
+        try:
+            BeautifulSoup(text, 'html.parser')
+        except Exception as e:
+            self.fail(f'Parsing of response failed with exception: {e}')
+
+    def test_query_unavailability_of_generation_units(self):
+        text = self.client.query_unavailability_of_generation_units(
+            country_code='BE', start=self.start,
+            end=self.end)
+        self.assertIsInstance(text, bytes)
+
+    def test_query_withdrawn_unavailability_of_generation_units(self):
+        with self.assertRaises(NoMatchingDataError):
+            self.client.query_withdrawn_unavailability_of_generation_units(
+                country_code='BE', start=self.start, end=self.end)
+
+
+class EntsoePandasClientTest(EntsoeRawClientTest):
+    @classmethod
+    def setUpClass(cls):
+        cls.client = EntsoePandasClient(api_key=api_key)
+        cls.start = pd.Timestamp('20180101', tz='Europe/Brussels')
+        cls.end = pd.Timestamp('20180107', tz='Europe/Brussels')
+        cls.country_code = 'BE'
+
+    def test_basic_queries(self):
+        pass
+
+    def test_basic_series(self):
+        queries = [
+            self.client.query_day_ahead_prices,
+            self.client.query_load,
+        ]
+        for query in queries:
+            ts = query(country_code=self.country_code, start=self.start,
+                       end=self.end)
+            self.assertIsInstance(ts, pd.Series)
+
+    def query_crossborder_flows(self):
+        ts = self.client.query_crossborder_flows(
+            country_code_from='BE', country_code_to='NL', start=self.start,
+            end=self.end)
+        self.assertIsInstance(ts, pd.Series)
+
+    def test_basic_dataframes(self):
+        queries = [
+            self.client.query_generation_forecast,
+            self.client.query_generation,
+            self.client.query_installed_generation_capacity,
+            self.client.query_imbalance_prices,
+            self.client.query_unavailability_of_generation_units,
+        ]
+        for query in queries:
+            ts = query(country_code=self.country_code, start=self.start,
+                       end=self.end)
+            self.assertIsInstance(ts, pd.DataFrame)
+
+    def test_query_unavailability_of_generation_units(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Getting ready for version 0.2:

- Split the original client in 2: `EntsoeRawClient` and `EntsoePandasClient`. This separates the raw server requests with the pandas parsing, which is way clearer imho.
- Wrappers to handle retrying after dropped connections, pagination, and requests that span more than 1 year.

To do:
- [x] Clean up parsers
- [x] Write readme