### PR TITLE
Unavailibility

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -394,7 +394,8 @@ class EntsoeRawClient:
         return response.text
 
     def query_unavailability(self, country_code, start, end, 
-                                        doctype, docstatus=None) -> bytes:
+                            doctype, docstatus=None, periodstartupdate = None, 
+                            periodendupdate = None) -> bytes:
         """
         Generic unavailibility query method.
         This endpoint serves ZIP files.
@@ -407,6 +408,8 @@ class EntsoeRawClient:
         end : pd.Timestamp
         doctype : str
         docstatus : str, optional
+        periodStartUpdate : pd.Timestamp, optional
+        periodEndUpdate : pd.Timestamp, optional
 
         Returns
         -------
@@ -421,13 +424,17 @@ class EntsoeRawClient:
 
         if docstatus:
             params['docStatus'] = docstatus
+        if periodstartupdate and periodendupdate:
+            params['periodStartUpdate'] = self._datetime_to_str(periodstartupdate)
+            params['periodEndUpdate'] = self._datetime_to_str(periodendupdate)
 
         response = self.base_request(params=params, start=start, end=end)
 
         return response.content
 
     def query_unavailability_of_generation_units(self, country_code, start, end,
-                                                 docstatus=None) -> bytes:
+                                     docstatus=None, periodstartupdate = None, 
+                                     periodendupdate = None) -> bytes:
         """
         This endpoint serves ZIP files.
         The query is limited to 200 items per request.
@@ -438,6 +445,8 @@ class EntsoeRawClient:
         start : pd.Timestamp
         end : pd.Timestamp
         docstatus : str, optional
+        periodStartUpdate : pd.Timestamp, optional
+        periodEndUpdate : pd.Timestamp, optional
 
         Returns
         -------
@@ -445,11 +454,14 @@ class EntsoeRawClient:
         """
         content = self.query_unavailability(
             country_code=country_code, start=start, end=end, 
-            doctype="A77", docstatus=docstatus)
+            doctype="A77", docstatus=docstatus, 
+            periodstartupdate = periodstartupdate,
+            periodendupdate = periodendupdate)
         return content
         
     def query_unavailability_of_production_units(self, country_code, start, end,
-                                                 docstatus=None) -> bytes:
+                                     docstatus=None, periodstartupdate = None, 
+                                     periodendupdate = None) -> bytes:
         """
         This endpoint serves ZIP files.
         The query is limited to 200 items per request.
@@ -460,6 +472,8 @@ class EntsoeRawClient:
         start : pd.Timestamp
         end : pd.Timestamp
         docstatus : str, optional
+        periodStartUpdate : pd.Timestamp, optional
+        periodEndUpdate : pd.Timestamp, optional
 
         Returns
         -------
@@ -467,7 +481,9 @@ class EntsoeRawClient:
         """
         content = self.query_unavailability(
             country_code=country_code, start=start, end=end, 
-            doctype="A80", docstatus=docstatus)
+            doctype="A80", docstatus=docstatus, 
+            periodstartupdate = periodstartupdate,
+            periodendupdate = periodendupdate)
         return content
 
     def query_withdrawn_unavailability_of_generation_units(
@@ -713,7 +729,8 @@ class EntsoePandasClient(EntsoeRawClient):
     @year_limited
     @paginated
     def query_unavailability_of_generation_units(self, country_code, start, end,
-                                                 docstatus=None):
+                                     docstatus=None, periodstartupdate = None, 
+                                     periodendupdate = None):
         """
         Parameters
         ----------
@@ -721,6 +738,8 @@ class EntsoePandasClient(EntsoeRawClient):
         start : pd.Timestamp
         end : pd.Timestamp
         docstatus : str, optional
+        periodStartUpdate : pd.Timestamp, optional
+        periodEndUpdate : pd.Timestamp, optional
 
         Returns
         -------
@@ -729,7 +748,8 @@ class EntsoePandasClient(EntsoeRawClient):
         content = super(EntsoePandasClient,
                         self).query_unavailability_of_generation_units(
             country_code=country_code, start=start, end=end,
-            docstatus=docstatus)
+            docstatus=docstatus,  periodstartupdate = periodstartupdate,
+            periodendupdate = periodendupdate)
         df = parse_unavailabilities(content)
         df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
         df['start'] = df['start'].apply(lambda x: x.tz_convert(TIMEZONE_MAPPINGS[country_code]))
@@ -739,7 +759,8 @@ class EntsoePandasClient(EntsoeRawClient):
     @year_limited
     @paginated
     def query_unavailability_of_production_units(self, country_code, start, end,
-                                                 docstatus=None):
+                                     docstatus=None, periodstartupdate = None, 
+                                     periodendupdate = None):
         """
         Parameters
         ----------
@@ -747,6 +768,8 @@ class EntsoePandasClient(EntsoeRawClient):
         start : pd.Timestamp
         end : pd.Timestamp
         docstatus : str, optional
+        periodStartUpdate : pd.Timestamp, optional
+        periodEndUpdate : pd.Timestamp, optional
 
         Returns
         -------
@@ -755,7 +778,8 @@ class EntsoePandasClient(EntsoeRawClient):
         content = super(EntsoePandasClient,
                         self).query_unavailability_of_production_units(
             country_code=country_code, start=start, end=end,
-            docstatus=docstatus)
+            docstatus=docstatus, periodstartupdate = periodstartupdate,
+            periodendupdate = periodendupdate)
         df = parse_unavailabilities(content)
         df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
         df['start'] = df['start'].apply(lambda x: x.tz_convert(TIMEZONE_MAPPINGS[country_code]))

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -728,6 +728,38 @@ class EntsoePandasClient(EntsoeRawClient):
 
     @year_limited
     @paginated
+    def query_unavailability(self, country_code, start, end, doctype,
+                                     docstatus=None, periodstartupdate = None, 
+                                     periodendupdate = None):
+        """
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+        doctype : str
+        docstatus : str, optional
+        periodStartUpdate : pd.Timestamp, optional
+        periodEndUpdate : pd.Timestamp, optional
+
+        Returns
+        -------
+        pd.DataFrame
+        """
+        content = super(EntsoePandasClient,
+                        self).query_unavailability(
+            country_code=country_code, start=start, end=end, doctype = doctype,
+            docstatus=docstatus,  periodstartupdate = periodstartupdate,
+            periodendupdate = periodendupdate)
+        df = parse_unavailabilities(content)
+        df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
+        df['start'] = df['start'].apply(lambda x: x.tz_convert(TIMEZONE_MAPPINGS[country_code]))
+        df['end'] = df['end'].apply(lambda x: x.tz_convert(TIMEZONE_MAPPINGS[country_code]))
+        return df
+
+    
+    @year_limited
+    @paginated
     def query_unavailability_of_generation_units(self, country_code, start, end,
                                      docstatus=None, periodstartupdate = None, 
                                      periodendupdate = None):

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -393,6 +393,39 @@ class EntsoeRawClient:
         response = self.base_request(params=params, start=start, end=end)
         return response.text
 
+    def query_unavailability(self, country_code, start, end, 
+                                        doctype, docstatus=None) -> bytes:
+        """
+        Generic unavailibility query method.
+        This endpoint serves ZIP files.
+        The query is limited to 200 items per request.
+
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+        doctype : str
+        docstatus : str, optional
+
+        Returns
+        -------
+        bytes
+        """
+        domain = BIDDING_ZONES[country_code]
+        params = {
+            'documentType': doctype,
+            'biddingZone_domain': domain
+            # ,'businessType': 'A53 (unplanned) | A54 (planned)'
+        }
+
+        if docstatus:
+            params['docStatus'] = docstatus
+
+        response = self.base_request(params=params, start=start, end=end)
+
+        return response.content
+
     def query_unavailability_of_generation_units(self, country_code, start, end,
                                                  docstatus=None) -> bytes:
         """
@@ -410,19 +443,32 @@ class EntsoeRawClient:
         -------
         bytes
         """
-        domain = BIDDING_ZONES[country_code]
-        params = {
-            'documentType': 'A77',
-            'biddingZone_domain': domain
-            # ,'businessType': 'A53 (unplanned) | A54 (planned)'
-        }
+        content = self.query_unavailability(
+            country_code=country_code, start=start, end=end, 
+            doctype="A77", docstatus='A13')
+        return content
+        
+    def query_unavailability_of_production_units(self, country_code, start, end,
+                                                 docstatus=None) -> bytes:
+        """
+        This endpoint serves ZIP files.
+        The query is limited to 200 items per request.
 
-        if docstatus:
-            params['docStatus'] = docstatus
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+        docstatus : str, optional
 
-        response = self.base_request(params=params, start=start, end=end)
-
-        return response.content
+        Returns
+        -------
+        bytes
+        """
+        content = self.query_unavailability(
+            country_code=country_code, start=start, end=end, 
+            doctype="A80", docstatus='A13')
+        return content
 
     def query_withdrawn_unavailability_of_generation_units(
             self, country_code, start, end):
@@ -433,8 +479,9 @@ class EntsoeRawClient:
         start : pd.Timestamp
         end : pd.Timestamp
         """
-        content = self.query_unavailability_of_generation_units(
-            country_code=country_code, start=start, end=end, docstatus='A13')
+        content = self.query_unavailability(
+            country_code=country_code, start=start, end=end, 
+            doctype="A77", docstatus='A13')
         return content
 
 
@@ -681,6 +728,32 @@ class EntsoePandasClient(EntsoeRawClient):
         """
         content = super(EntsoePandasClient,
                         self).query_unavailability_of_generation_units(
+            country_code=country_code, start=start, end=end,
+            docstatus=docstatus)
+        df = parse_unavailabilities(content)
+        df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
+        df['start'] = df['start'].apply(lambda x: x.tz_convert(TIMEZONE_MAPPINGS[country_code]))
+        df['end'] = df['end'].apply(lambda x: x.tz_convert(TIMEZONE_MAPPINGS[country_code]))
+        return df
+
+    @year_limited
+    @paginated
+    def query_unavailability_of_production_units(self, country_code, start, end,
+                                                 docstatus=None):
+        """
+        Parameters
+        ----------
+        country_code : str
+        start : pd.Timestamp
+        end : pd.Timestamp
+        docstatus : str, optional
+
+        Returns
+        -------
+        pd.DataFrame
+        """
+        content = super(EntsoePandasClient,
+                        self).query_unavailability_of_production_units(
             country_code=country_code, start=start, end=end,
             docstatus=docstatus)
         df = parse_unavailabilities(content)

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -445,7 +445,7 @@ class EntsoeRawClient:
         """
         content = self.query_unavailability(
             country_code=country_code, start=start, end=end, 
-            doctype="A77", docstatus='A13')
+            doctype="A77", docstatus=docstatus)
         return content
         
     def query_unavailability_of_production_units(self, country_code, start, end,
@@ -467,7 +467,7 @@ class EntsoeRawClient:
         """
         content = self.query_unavailability(
             country_code=country_code, start=start, end=end, 
-            doctype="A80", docstatus='A13')
+            doctype="A80", docstatus=docstatus)
         return content
 
     def query_withdrawn_unavailability_of_generation_units(

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -410,7 +410,7 @@ class EntsoeRawClient:
         -------
         bytes
         """
-        domain = DOMAIN_MAPPINGS[country_code]
+        domain = BIDDING_ZONES[country_code]
         params = {
             'documentType': 'A77',
             'biddingZone_domain': domain

--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -371,19 +371,23 @@ def _available_period(timeseries: bs4.BeautifulSoup) -> list:
 
 
 def _unavailability_timeseries(soup: bs4.BeautifulSoup) -> list:
-    #if not ts:
-    #    return
+
+    # Avoid attribute errors when some of the fields are void: 
+    get_attr = lambda attr: "" if soup.find(attr) is None else soup.find(attr).text 
+    # When no nominal power is given, give default numeric value of 0:
+    get_float = lambda val: 0 if val == "" else float(val)
+
     dm = {k: v for (v, k) in BIDDING_ZONES.items()}
-    f = [BSNTYPE[soup.find('businesstype').text],
-         dm[soup.find('biddingzone_domain.mrid').text],
-         soup.find('quantity_measure_unit.name').text,
-         soup.find('curvetype').text,
-         soup.find('production_registeredresource.mrid').text,
-         soup.find('production_registeredresource.name').text,
-         soup.find('production_registeredresource.location.name').text,
-         PSRTYPE_MAPPINGS[soup.find(
-             'production_registeredresource.psrtype.psrtype').text],
-         float(soup.find('production_registeredresource.psrtype.powersystemresources.nominalp').text)]
+    f = [BSNTYPE[get_attr('businesstype')],
+         dm[get_attr('biddingzone_domain.mrid')],
+         get_attr('quantity_measure_unit.name'),
+         get_attr('curvetype'),
+         get_attr('production_registeredresource.mrid'),
+         get_attr('production_registeredresource.name'),
+         get_attr('production_registeredresource.location.name'),
+         PSRTYPE_MAPPINGS.get(get_attr(
+             'production_registeredresource.psrtype.psrtype'), ""),
+         get_float(get_attr('production_registeredresource.psrtype.powersystemresources.nominalp'))]
     return [f + p for p in _available_period(soup)]
 
 
@@ -409,7 +413,11 @@ def _outage_parser(xml_file: bytes) -> pd.DataFrame:
                'avail_qty'
                ]
     soup = bs4.BeautifulSoup(xml_text, 'html.parser')
-    creation_date = pd.Timestamp(soup.createddatetime.text)
+    try:
+        creation_date = pd.Timestamp(soup.createddatetime.text)
+    except AttributeError:
+        creation_date = ""
+
     try:
         docstatus = DOCSTATUS[soup.docstatus.value.text]
     except AttributeError:

--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -375,7 +375,7 @@ def _unavailability_timeseries(soup: bs4.BeautifulSoup) -> list:
     # Avoid attribute errors when some of the fields are void: 
     get_attr = lambda attr: "" if soup.find(attr) is None else soup.find(attr).text 
     # When no nominal power is given, give default numeric value of 0:
-    get_float = lambda val: 0 if val == "" else float(val)
+    get_float = lambda val: float('NaN') if val == "" else float(val)
 
     dm = {k: v for (v, k) in BIDDING_ZONES.items()}
     f = [BSNTYPE[get_attr('businesstype')],

--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -252,7 +252,7 @@ def _parse_generation_forecast_timeseries(soup):
 
     series.name = PSRTYPE_MAPPINGS[psrtype]
     return series
-	
+    
 def _parse_generation_forecast_timeseries_per_plant(soup):
     """
     Parameters


### PR DESCRIPTION
Some work on unavailibility queries:
- extend to unavl. queries to bidding zones (e.g. query for IT-NORD in addition to IT)
- implement query of production unit unavailibility (different than generation unavailibility)
- additional robustness to parse unavailibility for GB (i.e. multiple empty fields generated AttributeErrors)

Best regards,
Johan.
