### PR TITLE
fixed bug and refractored code for query_unavailability methods in En…

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -838,8 +838,6 @@ class EntsoePandasClient(EntsoeRawClient):
         df = df.truncate(before=start, after=end)
         return df
 
-    @year_limited
-    @paginated
     def query_unavailability_of_generation_units(self, country_code, start, end,
                                      docstatus=None, periodstartupdate = None,
                                      periodendupdate = None):
@@ -857,19 +855,12 @@ class EntsoePandasClient(EntsoeRawClient):
         -------
         pd.DataFrame
         """
-        df = super(EntsoePandasClient,
-                        self).query_unavailability_of_generation_units(
-            country_code=country_code, start=start, end=end,
-            docstatus=docstatus,  periodstartupdate = periodstartupdate,
-            periodendupdate = periodendupdate)
-        df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
-        df['start'] = df['start'].apply(lambda x: x.tz_convert(TIMEZONE_MAPPINGS[country_code]))
-        df['end'] = df['end'].apply(lambda x: x.tz_convert(TIMEZONE_MAPPINGS[country_code]))
-        df = df.truncate(before=start, after=end)
+
+        df = self.query_unavailability(country_code=country_code, start=start, end=end,
+                                       doctype="A80", docstatus=docstatus, periodstartupdate=periodstartupdate,
+                                       periodendupdate=periodendupdate)
         return df
 
-    @year_limited
-    @paginated
     def query_unavailability_of_production_units(self, country_code, start, end,
                                      docstatus=None, periodstartupdate = None,
                                      periodendupdate = None):
@@ -887,16 +878,9 @@ class EntsoePandasClient(EntsoeRawClient):
         -------
         pd.DataFrame
         """
-        content = super(EntsoePandasClient,
-                        self).query_unavailability_of_production_units(
-            country_code=country_code, start=start, end=end,
-            docstatus=docstatus, periodstartupdate = periodstartupdate,
-            periodendupdate = periodendupdate)
-        df = parse_unavailabilities(content)
-        df = df.tz_convert(TIMEZONE_MAPPINGS[country_code])
-        df['start'] = df['start'].apply(lambda x: x.tz_convert(TIMEZONE_MAPPINGS[country_code]))
-        df['end'] = df['end'].apply(lambda x: x.tz_convert(TIMEZONE_MAPPINGS[country_code]))
-        df = df.truncate(before=start, after=end)
+        df = self.query_unavailability(country_code=country_code, start=start, end=end,
+                                       doctype="A77", docstatus=docstatus, periodstartupdate=periodstartupdate,
+                                       periodendupdate=periodendupdate)
         return df
 
     def query_withdrawn_unavailability_of_generation_units(


### PR DESCRIPTION
There were some issues in the query_unavailability_xxx_units methods from the EntsoePandasClient.

```
    def query_unavailability_of_production_units(...):
        content = super(EntsoePandasClient,
                        self).query_unavailability_of_production_units(...)
```

this basically called following methods:

`EntsoePandasClient.query_unavailability_of_production_units(...)` ->
`EntsoeRawClient.query_unavailability_of_production_units(...)` ->
`EntsoePandasClient.query_unavailability(...)` 

That's why the data came out already parsed and parse_unavailabilities threw an Exception. The wrapper methods  'year_limited ` and  `paginated` were also called twice: Once in `EntsoePandasClient.query_unavailability_of_production_units` and again in  `EntsoePandasClient.query_unavailability_of_production_units `,  which is unnecessary.

I refactored the code, so that the methods are called in following oder:

 `EntsoePandasClient.query_unavailability_of_xxx_units` ->
`EntsoePandasClient.query_unavailability(...)`-> 
`EntsoeRawClient.query_unavailability(...)`

I also removed wrapper functions from  `EntsoePandasClient.query_unavailability_of_xxx_units`, because `EntsoePandasClient.query_unavailability(...)` is already wrapped. 




