### PR TITLE
Fix typo in timezone_mappings DE_AMPRION

### DIFF
--- a/entsoe/mappings.py
+++ b/entsoe/mappings.py
@@ -92,7 +92,7 @@ TIMEZONE_MAPPINGS = {
     'CZ': 'Europe/Prague',
     'DE': 'Europe/Berlin',
     'DE-50HZ': 'Europe/Berlin',
-    'DE-AMPRIRON': 'Europe/Berlin',
+    'DE-AMPRION': 'Europe/Berlin',
     'DE-TENNET': 'Europe/Berlin',
     'DE-TRANSNET': 'Europe/Berlin',
     'DE-LU': 'Europe/Berlin',


### PR DESCRIPTION
There was a typo in the timezone_mappings for DE_AMPRION, which resulted in an error when trying to retrieve data for this area. 