### PR TITLE
Handle NoMatchingData for partial requests

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -561,8 +561,15 @@ def year_limited(func):
     @wraps(func)
     def year_wrapper(*args, start, end, **kwargs):
         blocks = year_blocks(start, end)
-        frames = [func(*args, start=_start, end=_end, **kwargs) for _start, _end
-                  in blocks]
+        frames = []
+        for _start, _end in blocks:
+            try:
+                frame = func(*args, start=_start, end=_end, **kwargs)
+            except NoMatchingDataError:
+                print(f"NoMatchingDataError: between {_start} and {_end}")
+                frame = pd.DataFrame()
+            frames.append(frame)
+
         df = pd.concat(frames)
         return df
 
@@ -576,8 +583,15 @@ def day_limited(func):
     @wraps(func)
     def day_wrapper(*args, start, end, **kwargs):
         blocks = day_blocks(start, end)
-        frames = [func(*args, start=_start, end=_end, **kwargs) for _start, _end
-                  in blocks]
+        frames = []
+        for _start, _end in blocks:
+            try:
+                frame = func(*args, start=_start, end=_end, **kwargs)
+            except NoMatchingDataError:
+                print(f"NoMatchingDataError: between {_start} and {_end}")
+                frame = pd.DataFrame()
+            frames.append(frame)
+
         df = pd.concat(frames)
         return df
 

--- a/entsoe/misc.py
+++ b/entsoe/misc.py
@@ -27,6 +27,30 @@ def year_blocks(start, end):
     return res
 
 
+def month_blocks(start, end):
+    """
+    Create pairs of start and end with max a month in between, to deal with usage restrictions on the API
+
+    Parameters
+    ----------
+    start : dt.datetime | pd.Timestamp
+    end : dt.datetime | pd.Timestamp
+
+    Returns
+    -------
+    ((pd.Timestamp, pd.Timestamp))
+    """
+    rule = rrule.MONTHLY
+
+    res = []
+    for day in rrule.rrule(rule, dtstart=start, until=end):
+        res.append(pd.Timestamp(day))
+    res.append(end)
+    res = sorted(set(res))
+    res = pairwise(res)
+    return res
+
+
 def day_blocks(start, end):
     """
     Create pairs of start and end with max a day in between, to deal with usage restrictions on the API


### PR DESCRIPTION
Thank you for making this! While using this, I found something a bit troublesome that I wanted to solve, and here is my solution.

The year_limited and day_limited wrapper functions breaks apart a large
request into pieces. If one of these pieces return "NoMatchingData" the
entire request stops. With this change we make it print a line and
continue instead.