### PR TITLE
Add COBRAcable between DK-1 and NL

### DIFF
--- a/entsoe/mappings.py
+++ b/entsoe/mappings.py
@@ -275,7 +275,7 @@ PROCESSTYPE = {
 # neighbouring bidding zones that have cross-border flows
 NEIGHBOURS = {
     'BE': ['NL', 'DE-AT-LU', 'FR', 'GB', 'DE-LU'],
-    'NL': ['BE', 'DE-AT-LU', 'DE-LU', 'GB', 'NO-2'],
+    'NL': ['BE', 'DE-AT-LU', 'DE-LU', 'GB', 'NO-2', 'DK-1'],
     'DE-AT-LU': ['BE', 'CH', 'CZ', 'DK-1', 'DK-2', 'FR', 'IT-NORD', 'IT-NORD-AT', 'NL', 'PL', 'SE-4', 'SI'],
     'FR': ['BE', 'CH', 'DE-AT-LU', 'DE-LU', 'ES', 'GB', 'IT-NORD', 'IT-NORD-FR'],
     'CH': ['AT', 'DE-AT-LU', 'DE-LU', 'FR', 'IT-NORD', 'IT-NORD-CH'],
@@ -290,7 +290,7 @@ NEIGHBOURS = {
     'RS': ['AL', 'BA', 'BG', 'HR', 'HU', 'ME', 'MK', 'RO'],
     'PL': ['CZ', 'DE-AT-LU', 'DE-LU', 'LT', 'SE-4', 'SK', 'UA'],
     'ME': ['AL', 'BA', 'RS'],
-    'DK-1': ['DE-AT-LU', 'DE-LU', 'DK-2', 'NO-2', 'SE-3'],
+    'DK-1': ['DE-AT-LU', 'DE-LU', 'DK-2', 'NO-2', 'SE-3', 'NL'],
     'RO': ['BG', 'HU', 'RS', 'UA'],
     'LT': ['BY', 'LV', 'PL', 'RU-KGD', 'SE-4'],
     'BG': ['GR', 'MK', 'RO', 'RS', 'TR'],


### PR DESCRIPTION
On September 2019 the COBRAcable between DK-1 and NL was commissioned:

Resources:

- [Description by Energinet](https://en.energinet.dk/Infrastructure-Projects/Projektliste/COBRAcable)
- [Data on Transparency platform](https://transparency.entsoe.eu/transmission-domain/physicalFlow/show?name=&defaultValue=false&viewType=TABLE&areaType=BORDER_BZN&atch=false&dateTime.dateTime=19.05.2020+00:00|CET|DAY&border.values=CTY|10Y1001A1001A65H!BZN_BZN|10YDK-1--------W_BZN_BZN|10YNL----------L&dateTime.timezone=CET_CEST&dateTime.timezone_input=CET+(UTC+1)+/+CEST+(UTC+2))