### PR TITLE
query_installed_generation_capacity to include BIDDING_ZONES

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -345,7 +345,7 @@ class EntsoeRawClient:
         -------
         str
         """
-        domain = DOMAIN_MAPPINGS[country_code]
+        domain = BIDDING_ZONES[country_code]
         params = {
             'documentType': 'A68',
             'processType': 'A33',


### PR DESCRIPTION
query_installed_generation_capacity can have seperate bidding zones, does not need to be specific domain