### PR TITLE
fix: finds last time series `end` tag occurring in some XML soups

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -446,7 +446,7 @@ def _parse_datetimeindex(soup, tz = None):
     pd.DatetimeIndex
     """
     start = pd.Timestamp(soup.find('start').text)
-    end = pd.Timestamp(soup.find('end').text)
+    end = pd.Timestamp(soup.find_all('end')[-1].text)
     if tz is not None:
         start = start.tz_convert(tz)
         end = end.tz_convert(tz)


### PR DESCRIPTION
Minimal fix for https://github.com/EnergieID/entsoe-py/issues/71.