### PR TITLE
Improved generation parsing

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -15,12 +15,11 @@ from .exceptions import NoMatchingDataError, PaginationError
 from .mappings import Area, NEIGHBOURS, lookup_area
 from .misc import year_blocks, day_blocks
 from .parsers import parse_prices, parse_loads, parse_generation, \
-    parse_generation_per_plant, parse_installed_capacity_per_plant, \
-    parse_crossborder_flows, parse_unavailabilities, \
-    parse_contracted_reserve, parse_imbalance_prices_zip
+    parse_installed_capacity_per_plant, parse_crossborder_flows, \
+    parse_unavailabilities, parse_contracted_reserve, parse_imbalance_prices_zip
 
 __title__ = "entsoe-py"
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __author__ = "EnergieID.be"
 __license__ = "MIT"
 
@@ -942,7 +941,8 @@ class EntsoePandasClient(EntsoeRawClient):
     @year_limited
     def query_generation_forecast(
             self, country_code: Union[Area, str], start: pd.Timestamp,
-            end: pd.Timestamp, process_type: str = 'A01') -> pd.Series:
+            end: pd.Timestamp, process_type: str = 'A01',
+            nett: bool = False) -> Union[pd.DataFrame, pd.Series]:
         """
         Parameters
         ----------
@@ -950,18 +950,20 @@ class EntsoePandasClient(EntsoeRawClient):
         start : pd.Timestamp
         end : pd.Timestamp
         process_type : str
+        nett : bool
+            condense generation and consumption into a nett number
 
         Returns
         -------
-        pd.Series
+        pd.DataFrame | pd.Series
         """
         area = lookup_area(country_code)
         text = super(EntsoePandasClient, self).query_generation_forecast(
             country_code=area, start=start, end=end, process_type=process_type)
-        series = parse_loads(text)
-        series = series.tz_convert(area.tz)
-        series = series.truncate(before=start, after=end)
-        return series
+        df = parse_generation(text, nett=nett)
+        df = df.tz_convert(area.tz)
+        df = df.truncate(before=start, after=end)
+        return df
 
     @year_limited
     def query_wind_and_solar_forecast(
@@ -986,7 +988,7 @@ class EntsoePandasClient(EntsoeRawClient):
         text = super(EntsoePandasClient, self).query_wind_and_solar_forecast(
             country_code=area, start=start, end=end, psr_type=psr_type,
             process_type=process_type)
-        df = parse_generation(text)
+        df = parse_generation(text, nett=True)
         df = df.tz_convert(area.tz)
         df = df.truncate(before=start, after=end)
         return df
@@ -995,7 +997,7 @@ class EntsoePandasClient(EntsoeRawClient):
     def query_generation(
             self, country_code: Union[Area, str], start: pd.Timestamp,
             end: pd.Timestamp, psr_type: Optional[str] = None,
-            **kwargs) -> pd.DataFrame:
+            nett: bool = False, **kwargs) -> pd.DataFrame:
         """
         Parameters
         ----------
@@ -1004,6 +1006,8 @@ class EntsoePandasClient(EntsoeRawClient):
         end : pd.Timestamp
         psr_type : str
             filter on a single psr type
+        nett : bool
+            condense generation and consumption into a nett number
 
         Returns
         -------
@@ -1012,7 +1016,7 @@ class EntsoePandasClient(EntsoeRawClient):
         area = lookup_area(country_code)
         text = super(EntsoePandasClient, self).query_generation(
             country_code=area, start=start, end=end, psr_type=psr_type)
-        df = parse_generation(text)
+        df = parse_generation(text, nett=nett)
         df = df.tz_convert(area.tz)
         df = df.truncate(before=start, after=end)
         return df
@@ -1361,7 +1365,7 @@ class EntsoePandasClient(EntsoeRawClient):
     def query_generation_per_plant(
             self, country_code: Union[Area, str], start: pd.Timestamp,
             end: pd.Timestamp, psr_type: Optional[str] = None,
-            **kwargs) -> pd.DataFrame:
+            nett: bool = False, **kwargs) -> pd.DataFrame:
         """
         Parameters
         ----------
@@ -1370,6 +1374,8 @@ class EntsoePandasClient(EntsoeRawClient):
         end : pd.Timestamp
         psr_type : str
             filter on a single psr type
+        nett : bool
+            condense generation and consumption into a nett number
 
         Returns
         -------
@@ -1378,7 +1384,7 @@ class EntsoePandasClient(EntsoeRawClient):
         area = lookup_area(country_code)
         text = super(EntsoePandasClient, self).query_generation_per_plant(
             country_code=area, start=start, end=end, psr_type=psr_type)
-        df = parse_generation_per_plant(text)
+        df = parse_generation(text, per_plant=True)
         df = df.tz_convert(area.tz)
         # Truncation will fail if data is not sorted along the index in rare
         # cases. Ensure the dataframe is sorted:


### PR DESCRIPTION
Improvements for all generation queries:
- `query_generation`
- `query_generation_forecast`
- `query_wind_and_solar_forecast`
- `query_generation_per_plant`

All 4 generation methods now use the same parser.
Parsing of a generation timeseries now parses (up to) 3 headers:
- PSRTYPE
- Whether it is Actual Generation or Consumption
- The plant name (in case of `query_generation_per_plant`.

If you pass the argument `nett=True`, Consumption is subtracted from the Actual Generation and returned as a single column (this is the behaviour that is similar to before this update).

Rendundant or non-relevant headers are automatically omitted.

