### PR TITLE
Feature/utf 8 plant data

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1509,6 +1509,7 @@ class EntsoePandasClient(EntsoeRawClient):
         text = super(EntsoePandasClient, self).query_generation_per_plant(
             country_code=area, start=start, end=end, psr_type=psr_type)
         df = parse_generation(text, per_plant=True)
+        df.columns = df.columns.set_levels(df.columns.levels[0].str.encode('latin-1').str.decode('utf-8'), level=0)
         df = df.tz_convert(area.tz)
         # Truncation will fail if data is not sorted along the index in rare
         # cases. Ensure the dataframe is sorted:

--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -164,6 +164,7 @@ def parse_installed_capacity_per_plant(xml_text):
 
     df = pd.DataFrame.from_dict(all_series).T
     df['Production Type'] = df['Production Type'].map(PSRTYPE_MAPPINGS)
+    df['Name'] = df['Name'].str.encode('latin-1').str.decode('utf-8')
     #    df['Status'] = df['Status'].map(BSNTYPE)
     return df
 


### PR DESCRIPTION
Plant Names are encoded in Latin-1 but python uses UTF-8, so we should show the correctly encoded data.

This pull request fixes the encoding for the names column in 

`query_installed_generation_capacity_per_unit` and `query_generation_per_plant`