### PR TITLE
Id implicit offered capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ client = EntsoeRawClient(api_key=<YOUR API KEY>)
 start = pd.Timestamp('20171201', tz='Europe/Brussels')
 end = pd.Timestamp('20180101', tz='Europe/Brussels')
 country_code = 'BE'  # Belgium
+country_code_from = 'FR'  # France
+country_code_to = 'DE_LU' # Germany-Luxembourg
+type_marketagreement_type = 'A01'
 
 # methods that return XML
 client.query_day_ahead_prices(country_code, start, end)
@@ -28,12 +31,25 @@ client.query_load_forecast(country_code, start, end)
 client.query_wind_and_solar_forecast(country_code, start, end, psr_type=None)
 client.query_generation_forecast(country_code, start, end)
 client.query_generation(country_code, start, end, psr_type=None)
+client.query_generation_per_plant(country_code, start, end, psr_type=None)
 client.query_installed_generation_capacity(country_code, start, end, psr_type=None)
+client.query_installed_generation_capacity_per_unit(country_code, start, end, psr_type=None)
 client.query_crossborder_flows(country_code_from, country_code_to, start, end)
-client.query_imbalance_prices(country_code, start, end, psr_type=None)
+client.query_scheduled_exchanges(country_code_from, country_code_to, start, end)
+client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to, start, end)
+client.query_net_transfer_capacity_weekahead(country_code_from, country_code_to, start, end)
+client.query_net_transfer_capacity_monthahead(country_code_from, country_code_to, start, end)
+client.query_net_transfer_capacity_yearahead(country_code_from, country_code_to, start, end)
+client.query_intraday_offered_capacity(country_code_from, country_code_to, start, end)
+client.query_contracted_reserve_prices(country_code, start, end, type_marketagreement_type, psr_type=None)
+client.query_contracted_reserve_amount(country_code, start, end, type_marketagreement_type, psr_type=None)
 
-# methods that return ZIP
-client.query_unavailability_of_generation_units(country_code, start, end, docstatus=None)
+
+# methods that return ZIP (bytes)
+client.query_imbalance_prices(country_code, start, end, psr_type=None)
+client.query_unavailability_of_generation_units(country_code, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
+client.query_unavailability_of_production_units(country_code, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
+client.query_unavailability_transmission(country_code_from, country_code_to, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
 client.query_withdrawn_unavailability_of_generation_units(country_code, start, end)
 ```
 #### Dump result to file
@@ -71,21 +87,39 @@ client = EntsoePandasClient(api_key=<YOUR API KEY>)
 start = pd.Timestamp('20171201', tz='Europe/Brussels')
 end = pd.Timestamp('20180101', tz='Europe/Brussels')
 country_code = 'BE'  # Belgium
+country_code_from = 'FR'  # France
+country_code_to = 'DE_LU' # Germany-Luxembourg
+type_marketagreement_type = 'A01'
 
 # methods that return Pandas Series
 client.query_day_ahead_prices(country_code, start=start,end=end)
 client.query_load(country_code, start=start,end=end)
 client.query_load_forecast(country_code, start=start,end=end)
-client.query_generation_forecast(country_code, start=start,end=end)
+client.query_crossborder_flows(country_code_from, country_code_to, start, end)
+client.query_scheduled_exchanges(country_code_from, country_code_to, start, end)
+client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to, start, end)
+client.query_net_transfer_capacity_weekahead(country_code_from, country_code_to, start, end)
+client.query_net_transfer_capacity_monthahead(country_code_from, country_code_to, start, end)
+client.query_net_transfer_capacity_yearahead(country_code_from, country_code_to, start, end)
+client.query_intraday_offered_capacity(country_code_from, country_code_to, start, end)
 
 # methods that return Pandas DataFrames
+client.query_generation_forecast(country_code, start=start,end=end)
 client.query_wind_and_solar_forecast(country_code, start=start,end=end, psr_type=None)
 client.query_generation(country_code, start=start,end=end, psr_type=None)
+client.query_generation_per_plant(country_code, start=start,end=end, psr_type=None)
 client.query_installed_generation_capacity(country_code, start=start,end=end, psr_type=None)
-client.query_crossborder_flows('DE', 'DK', start=start,end=end)
+client.query_installed_generation_capacity_per_unit(country_code, start=start,end=end, psr_type=None)
 client.query_imbalance_prices(country_code, start=start,end=end, psr_type=None)
-client.query_unavailability_of_generation_units(country_code, start=start,end=end, docstatus=None)
-client.query_withdrawn_unavailability_of_generation_units('DE', start=start,end=end)
+client.query_contracted_reserve_prices(country_code, start, end, type_marketagreement_type, psr_type=None)
+client.query_contracted_reserve_amount(country_code, start, end, type_marketagreement_type, psr_type=None)
+client.query_unavailability_of_generation_units(country_code, start=start,end=end, docstatus=None, periodstartupdate=None, periodendupdate=None)
+client.query_unavailability_of_production_units(country_code, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
+client.query_unavailability_transmission(country_code_from, country_code_to, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
+client.query_withdrawn_unavailability_of_generation_units(country_code, start, end)
+client.query_import(country_code, start, end)
+client.query_generation_import(country_code, start, end)
+
 ```
 #### Dump result to file
 See a list of all IO-methods on https://pandas.pydata.org/pandas-docs/stable/io.html
@@ -141,6 +175,7 @@ DOMAIN_MAPPINGS = {
     'TR': '10YTR-TEIAS----W',
     'UA': '10YUA-WEPS-----0',
     'DE_AT_LU': '10Y1001A1001A63L',
+    'DE_LU':'10Y1001A1001A82H',
 }
 ```
 ### Bidding Zones

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to, 
 client.query_net_transfer_capacity_weekahead(country_code_from, country_code_to, start, end)
 client.query_net_transfer_capacity_monthahead(country_code_from, country_code_to, start, end)
 client.query_net_transfer_capacity_yearahead(country_code_from, country_code_to, start, end)
-client.query_intraday_offered_capacity(country_code_from, country_code_to, start, end)
+client.query_intraday_offered_capacity(country_code_from, country_code_to, start, end, implicit=True)
 client.query_contracted_reserve_prices(country_code, start, end, type_marketagreement_type, psr_type=None)
 client.query_contracted_reserve_amount(country_code, start, end, type_marketagreement_type, psr_type=None)
 
@@ -101,7 +101,7 @@ client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to, 
 client.query_net_transfer_capacity_weekahead(country_code_from, country_code_to, start, end)
 client.query_net_transfer_capacity_monthahead(country_code_from, country_code_to, start, end)
 client.query_net_transfer_capacity_yearahead(country_code_from, country_code_to, start, end)
-client.query_intraday_offered_capacity(country_code_from, country_code_to, start, end)
+client.query_intraday_offered_capacity(country_code_from, country_code_to, start, end,implicit=True)
 
 # methods that return Pandas DataFrames
 client.query_generation_forecast(country_code, start=start,end=end)

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -550,7 +550,7 @@ class EntsoeRawClient:
             auction_type: Optional[str] = None) -> str:
         """
         Generic function called by query_crossborder_flows, 
-        query_scheduled_exchanges, query_net_transfer_capacity_DA/WA/MA/YA and query_.
+        query_scheduled_exchanges, query_net_transfer_capacity_DA/WA/MA/YA and query_intraday_offered_capacity.
 
         Parameters
         ----------

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -521,7 +521,7 @@ class EntsoeRawClient:
     def query_intraday_offered_capacity(
         self, country_code_from: Union[Area, str],
             country_code_to: Union[Area, str], start: pd.Timestamp,
-            end: pd.Timestamp, **kwargs) -> str:
+            end: pd.Timestamp, implicit:bool = True,**kwargs) -> str:
         """
         Parameters
         ----------
@@ -529,7 +529,7 @@ class EntsoeRawClient:
         country_code_to : Area|str
         start : pd.Timestamp
         end : pd.Timestamp
-
+        implicit: bool (True = implicit - default for most borders. False = explicit - for instance BE-GB)
 
         Returns
         -------
@@ -539,7 +539,7 @@ class EntsoeRawClient:
             country_code_from=country_code_from,
             country_code_to=country_code_to, start=start, end=end,
             doctype="A31", contract_marketagreement_type="A07",
-            auction_type="A01")
+            auction_type=("A01" if implicit==True else "A02"))
 
 
     def _query_crossborder(
@@ -550,7 +550,7 @@ class EntsoeRawClient:
             auction_type: Optional[str] = None) -> str:
         """
         Generic function called by query_crossborder_flows, 
-        query_scheduled_exchanges, query_net_transfer_capacity_DA/WA/MA/YA and query_intraday_offered_capacity.
+        query_scheduled_exchanges, query_net_transfer_capacity_DA/WA/MA/YA and query_.
 
         Parameters
         ----------
@@ -1292,7 +1292,7 @@ class EntsoePandasClient(EntsoeRawClient):
     def query_intraday_offered_capacity(
         self, country_code_from: Union[Area, str],
             country_code_to: Union[Area, str], start: pd.Timestamp,
-            end: pd.Timestamp, **kwargs) -> pd.Series:
+            end: pd.Timestamp, implicit:bool = True, **kwargs) -> pd.Series:
         """
         Note: Result will be in the timezone of the origin country  --> to check
 
@@ -1302,7 +1302,7 @@ class EntsoePandasClient(EntsoeRawClient):
         country_code_to : Area|str
         start : pd.Timestamp
         end : pd.Timestamp
-
+        implicit: bool (True = implicit - default for most borders. False = explicit - for instance BE-GB)
         Returns
         -------
         pd.Series
@@ -1313,7 +1313,8 @@ class EntsoePandasClient(EntsoeRawClient):
             country_code_from=area_from,
             country_code_to=area_to,
             start=start,
-            end=end)
+            end=end,
+            implicit=implicit)
         ts = parse_crossborder_flows(text)
         ts = ts.tz_convert(area_from.tz)
         ts = ts.truncate(before=start, after=end)

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -517,15 +517,40 @@ class EntsoeRawClient:
             country_code_from=country_code_from,
             country_code_to=country_code_to, start=start, end=end,
             doctype="A61", contract_marketagreement_type="A04")
+    
+    def query_intraday_offered_capacity(
+        self, country_code_from: Union[Area, str],
+            country_code_to: Union[Area, str], start: pd.Timestamp,
+            end: pd.Timestamp, **kwargs) -> str:
+        """
+        Parameters
+        ----------
+        country_code_from : Area|str
+        country_code_to : Area|str
+        start : pd.Timestamp
+        end : pd.Timestamp
+
+
+        Returns
+        -------
+        str
+        """
+        return self._query_crossborder(
+            country_code_from=country_code_from,
+            country_code_to=country_code_to, start=start, end=end,
+            doctype="A31", contract_marketagreement_type="A07",
+            auction_type="A01")
+
 
     def _query_crossborder(
             self, country_code_from: Union[Area, str],
             country_code_to: Union[Area, str], start: pd.Timestamp,
             end: pd.Timestamp, doctype: str,
-            contract_marketagreement_type: Optional[str] = None) -> str:
+            contract_marketagreement_type: Optional[str] = None,
+            auction_type: Optional[str] = None) -> str:
         """
-        Generic function called by query_crossborder_flows and
-        query_scheduled_exchanges.
+        Generic function called by query_crossborder_flows, 
+        query_scheduled_exchanges, query_net_transfer_capacity_DA/WA/MA/YA and query_.
 
         Parameters
         ----------
@@ -551,6 +576,9 @@ class EntsoeRawClient:
         if contract_marketagreement_type is not None:
             params[
                 'contract_MarketAgreement.Type'] = contract_marketagreement_type
+        if auction_type is not None:
+            params[
+                'Auction.Type'] = auction_type
 
         response = self._base_request(params=params, start=start, end=end)
         return response.text
@@ -795,6 +823,7 @@ class EntsoeRawClient:
             country_code=country_code, start=start, end=end,
             doctype="A80", docstatus='A13')
         return content
+    
 
 
 def paginated(func):
@@ -1227,7 +1256,7 @@ class EntsoePandasClient(EntsoeRawClient):
         ts = ts.tz_convert(area_from.tz)
         ts = ts.truncate(before=start, after=end)
         return ts
-
+    
     @year_limited
     def query_net_transfer_capacity_yearahead(
             self, country_code_from: Union[Area, str],
@@ -1259,6 +1288,37 @@ class EntsoePandasClient(EntsoeRawClient):
         ts = ts.truncate(before=start, after=end)
         return ts
 
+    @year_limited
+    def query_intraday_offered_capacity(
+        self, country_code_from: Union[Area, str],
+            country_code_to: Union[Area, str], start: pd.Timestamp,
+            end: pd.Timestamp, **kwargs) -> pd.Series:
+        """
+        Note: Result will be in the timezone of the origin country  --> to check
+
+        Parameters
+        ----------
+        country_code_from : Area|str
+        country_code_to : Area|str
+        start : pd.Timestamp
+        end : pd.Timestamp
+
+        Returns
+        -------
+        pd.Series
+        """
+        area_to = lookup_area(country_code_to)
+        area_from = lookup_area(country_code_from)
+        text = super(EntsoePandasClient, self).query_intraday_offered_capacity(
+            country_code_from=area_from,
+            country_code_to=area_to,
+            start=start,
+            end=end)
+        ts = parse_crossborder_flows(text)
+        ts = ts.tz_convert(area_from.tz)
+        ts = ts.truncate(before=start, after=end)
+        return ts
+    
     @year_limited
     def query_imbalance_prices(
             self, country_code: Union[Area, str], start: pd.Timestamp,
@@ -1559,3 +1619,4 @@ class EntsoePandasClient(EntsoeRawClient):
         df = pd.concat(data.values(), axis=1, keys=data.keys())
         df = df.truncate(before=start, after=end)
         return df
+


### PR DESCRIPTION
Implementation if query_intraday_offered_capacity allowing to retrieve the ID ATC for implicit allocation (final ID ATC after XBID or last one submitted if the delivery day is not yet closed as published on https://transparency.entsoe.eu/transmission-domain/r2/implicitAllocationsIntraday/show
I have not yet found a way to retrieve the OC evolution  as in https://transparency.entsoe.eu/transmission/r2/implicitOfferedIntradayTransferCapacities/show which returns ALL the evolution of ID ATC (including initial ID ATC + all variations after each trade).

Tested and validated with this code:
start = pd.Timestamp('20210329', tz='Europe/Brussels')
end = pd.Timestamp('20210330', tz='Europe/Brussels')
country_code_from = 'FR'  # 
country_code_to = 'DE_LU'
test=client.query_intraday_offered_capacity(country_code_from, country_code_to, start=start,end=end)
print(test)

+ also for BE-FR border

