### PR TITLE
Added query for day ahead net position

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ country_code = 'BE'  # Belgium
 
 # methods that return XML
 client.query_day_ahead_prices(country_code, start, end)
+client.query_net_position_dayahead(country_code, start, end)
 client.query_load(country_code, start, end)
 client.query_load_forecast(country_code, start, end)
 client.query_wind_and_solar_forecast(country_code, start, end, psr_type=None)
@@ -74,6 +75,7 @@ country_code = 'BE'  # Belgium
 
 # methods that return Pandas Series
 client.query_day_ahead_prices(country_code, start=start,end=end)
+client.query_net_position_dayahead(country_code, start=start, end=end)
 client.query_load(country_code, start=start,end=end)
 client.query_load_forecast(country_code, start=start,end=end)
 client.query_generation_forecast(country_code, start=start,end=end)

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -16,7 +16,8 @@ from .mappings import Area, NEIGHBOURS, lookup_area
 from .misc import year_blocks, day_blocks
 from .parsers import parse_prices, parse_loads, parse_generation, \
     parse_installed_capacity_per_plant, parse_crossborder_flows, \
-    parse_unavailabilities, parse_contracted_reserve, parse_imbalance_prices_zip
+    parse_unavailabilities, parse_contracted_reserve, parse_imbalance_prices_zip, \
+    parse_netpositions
 
 __title__ = "entsoe-py"
 __version__ = "0.3.3"
@@ -177,6 +178,30 @@ class EntsoeRawClient:
         area = lookup_area(country_code)
         params = {
             'documentType': 'A44',
+            'in_Domain': area.code,
+            'out_Domain': area.code
+        }
+        response = self._base_request(params=params, start=start, end=end)
+        return response.text
+    
+    def query_net_position_dayahead(self, country_code: Union[Area, str],
+                            start: pd.Timestamp, end: pd.Timestamp) -> str:
+        """
+        Parameters
+        ----------
+        country_code : Area|str
+        start : pd.Timestamp
+        end : pd.Timestamp
+
+        Returns
+        -------
+        str
+        """
+        area = lookup_area(country_code)
+        params = {
+            'documentType': 'A25',  # Allocation result document
+            'businessType': 'B09',  # net position
+            'Contract_MarketAgreement.Type': 'A01',  # daily
             'in_Domain': area.code,
             'out_Domain': area.code
         }
@@ -869,6 +894,29 @@ def day_limited(func):
 
 
 class EntsoePandasClient(EntsoeRawClient):
+    @year_limited
+    def query_net_position_dayahead(self, country_code: Union[Area, str],
+                            start: pd.Timestamp, end: pd.Timestamp) -> pd.Series:
+        """
+
+        Parameters
+        ----------
+        country_code
+        start
+        end
+
+        Returns
+        -------
+
+        """
+        area = lookup_area(country_code)
+        text = super(EntsoePandasClient, self).query_net_position_dayahead(
+            country_code=area, start=start, end=end)
+        series = parse_netpositions(text)
+        series = series.tz_convert(area.tz)
+        series = series.truncate(before=start, after=end)
+        return series
+
     @year_limited
     def query_day_ahead_prices(
             self, country_code: Union[Area, str], start: pd.Timestamp,

--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -365,9 +365,13 @@ def _parse_netposition_timeseries(soup):
     """
     positions = []
     quantities = []
+    if 'REGION' in soup.find('out_domain.mrid').text:
+        factor = -1 # flow is import so negative
+    else:
+        factor = 1
     for point in soup.find_all('point'):
         positions.append(int(point.find('position').text))
-        quantities.append(float(point.find('quantity').text))
+        quantities.append(factor * float(point.find('quantity').text))
 
     series = pd.Series(index=positions, data=quantities)
     series = series.sort_index()

--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -45,6 +45,24 @@ def parse_prices(xml_text):
     return series
 
 
+def parse_netpositions(xml_text):
+    """
+
+    Parameters
+    ----------
+    xml_text : str
+
+    Returns
+    -------
+    pd.Series
+    """
+    series = pd.Series()
+    for soup in _extract_timeseries(xml_text):
+        series = series.append(_parse_netposition_timeseries(soup))
+    series = series.sort_index()
+    return series
+
+
 def parse_loads(xml_text):
     """
     Parameters
@@ -333,6 +351,29 @@ def _parse_imbalance_prices_timeseries(soup) -> pd.DataFrame:
                        'None': 'Price for Consumption'}, inplace=True)
 
     return df
+
+
+def _parse_netposition_timeseries(soup):
+    """
+    Parameters
+    ----------
+    soup : bs4.element.tag
+
+    Returns
+    -------
+    pd.Series
+    """
+    positions = []
+    quantities = []
+    for point in soup.find_all('point'):
+        positions.append(int(point.find('position').text))
+        quantities.append(float(point.find('quantity').text))
+
+    series = pd.Series(index=positions, data=quantities)
+    series = series.sort_index()
+    series.index = _parse_datetimeindex(soup)
+
+    return series
 
 
 def _parse_price_timeseries(soup):

--- a/tests.py
+++ b/tests.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 
 from entsoe import EntsoeRawClient, EntsoePandasClient
 from entsoe.exceptions import NoMatchingDataError
-from settings import api_key
+from settings import *
 
 class EntsoeRawClientTest(unittest.TestCase):
     @classmethod
@@ -29,7 +29,9 @@ class EntsoeRawClientTest(unittest.TestCase):
             self.client.query_generation,
             self.client.query_generation_forecast,
             self.client.query_installed_generation_capacity,
-            self.client.query_imbalance_prices
+            # this one gives back a zip so disabled for testing right now
+            #self.client.query_imbalance_prices,
+            self.client.query_net_position_dayahead
         ]
         for query in queries:
             text = query(country_code=self.country_code, start=self.start,
@@ -78,7 +80,8 @@ class EntsoePandasClientTest(EntsoeRawClientTest):
             self.client.query_day_ahead_prices,
             self.client.query_load,
             self.client.query_load_forecast,
-            self.client.query_generation_forecast
+            self.client.query_generation_forecast,
+            self.client.query_net_position_dayahead
         ]
         for query in queries:
             ts = query(country_code=self.country_code, start=self.start,
@@ -97,7 +100,7 @@ class EntsoePandasClientTest(EntsoeRawClientTest):
             self.client.query_generation,
             self.client.query_installed_generation_capacity,
             self.client.query_imbalance_prices,
-            self.client.query_unavailability_of_generation_units,
+            self.client.query_unavailability_of_generation_units
         ]
         for query in queries:
             ts = query(country_code=self.country_code, start=self.start,


### PR DESCRIPTION
Hi,

I have added the day ahead net position end point as defined in section 4.2.11 of the API guide from ENTSO-E. I have tried to keep the coding style as the same as the existing code base as much as possible.

When adding my changes to the existing tests I found out they didnt succeed, I have fixed that as well.