### PR TITLE
Passing on the principle of netting generation & consumption for generation of specific units.

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1569,7 +1569,7 @@ class EntsoePandasClient(EntsoeRawClient):
         area = lookup_area(country_code)
         text = super(EntsoePandasClient, self).query_generation_per_plant(
             country_code=area, start=start, end=end, psr_type=psr_type)
-        df = parse_generation(text, per_plant=True)
+        df = parse_generation(text, per_plant=True, nett = nett)
         df.columns = df.columns.set_levels(df.columns.levels[0].str.encode('latin-1').str.decode('utf-8'), level=0)
         df = df.tz_convert(area.tz)
         # Truncation will fail if data is not sorted along the index in rare


### PR DESCRIPTION
Warning: I removed the df.squeeze() at the end of the netting, because it's an unsafe operation on dataframes:
df.squeeze() gives inconsistent results according to the number of columns in a dataframe. The structure of the columns becomes different if (by coincidence) only a single psr_type (in case of aggregated generation) or a single plant unit (in case of unit generation) is present in the queried data.
A specific column level can be removed with the following operation (=safer than squeeze):
df = df.droplevel(1, level_index)
(removing level_index of the multiindex column axis).

