### PR TITLE
style: suppress warnings

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -38,7 +38,7 @@ def parse_prices(xml_text):
     -------
     pd.Series
     """
-    series = pd.Series()
+    series = pd.Series(dtype = 'object')
     for soup in _extract_timeseries(xml_text):
         series = series.append(_parse_price_timeseries(soup))
     series = series.sort_index()
@@ -56,7 +56,7 @@ def parse_netpositions(xml_text):
     -------
     pd.Series
     """
-    series = pd.Series()
+    series = pd.Series(dtype = 'object')
     for soup in _extract_timeseries(xml_text):
         series = series.append(_parse_netposition_timeseries(soup))
     series = series.sort_index()
@@ -73,7 +73,7 @@ def parse_loads(xml_text):
     -------
     pd.Series
     """
-    series = pd.Series()
+    series = pd.Series(dtype = 'object')
     for soup in _extract_timeseries(xml_text):
         series = series.append(_parse_load_timeseries(soup))
     series = series.sort_index()
@@ -204,7 +204,7 @@ def parse_crossborder_flows(xml_text):
     -------
     pd.Series
     """
-    series = pd.Series()
+    series = pd.Series(dtype = 'object')
     for soup in _extract_timeseries(xml_text):
         series = series.append(_parse_crossborder_flows_timeseries(soup))
     series = series.sort_index()


### PR DESCRIPTION
When using the entsoe-py package, I noticed that a warning gets thrown a lot.
```
DeprecationWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.
-- Docs: https://docs.pytest.org/en/stable/warnings.html
```
This issue is not dramatic, but I don't like random warnings popping up all the time, that is why I fixed the issue in this PR.