### PR TITLE
Don't send debug messages to stdout for CLI compatibility.

### DIFF
--- a/entsoe/decorators.py
+++ b/entsoe/decorators.py
@@ -1,3 +1,4 @@
+import sys
 from socket import gaierror
 from time import sleep
 import requests
@@ -22,7 +23,7 @@ def retry(func):
             except (requests.ConnectionError, gaierror) as e:
                 error = e
                 print("Connection Error, retrying in {} seconds".format(
-                    self.retry_delay))
+                    self.retry_delay), file=sys.stderr)
                 sleep(self.retry_delay)
                 continue
             else:
@@ -90,7 +91,7 @@ def day_limited(func):
             try:
                 frame = func(*args, start=_start, end=_end, **kwargs)
             except NoMatchingDataError:
-                print(f"NoMatchingDataError: between {_start} and {_end}")
+                print(f"NoMatchingDataError: between {_start} and {_end}", file=sys.stderr)
                 frame = None
             frames.append(frame)
 

--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -1,3 +1,4 @@
+import sys
 import zipfile
 from io import BytesIO
 from typing import Union
@@ -357,7 +358,7 @@ def _parse_contracted_reserve_series(soup, tz, label):
     df.sort_index(inplace=True)
     index = _parse_datetimeindex(soup, tz)
     if len(index) > len(df.index):
-        print("Shortening index")
+        print("Shortening index", file=sys.stderr)
         df.index = index[:len(df.index)]
     else:
         df.index = index

--- a/tests.py
+++ b/tests.py
@@ -92,8 +92,6 @@ class EntsoePandasClientTest(EntsoeRawClientTest):
     def test_basic_series(self):
         queries = [
             self.client.query_day_ahead_prices,
-            self.client.query_load,
-            self.client.query_load_forecast,
             self.client.query_generation_forecast,
             self.client.query_net_position_dayahead
         ]
@@ -110,6 +108,8 @@ class EntsoePandasClientTest(EntsoeRawClientTest):
 
     def test_basic_dataframes(self):
         queries = [
+            self.client.query_load,
+            self.client.query_load_forecast,
             self.client.query_wind_and_solar_forecast,
             self.client.query_generation,
             self.client.query_installed_generation_capacity,


### PR DESCRIPTION
I have redirected calls to `print` to `stderr` in order to be able to use the library in a CLI tool that outputs JSONs. The problem was that instead of getting:
```json
{"data": [1,2,3]}
```
which can be parsed by any JSON parser, we were getting:
```json
Connection Error, retrying in 0 seconds.
{"data": [1,2,3]}
```
that needs to be cleaned up before parsing.