### PR TITLE
Added query for net position intraday

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ type_marketagreement_type = 'A01'
 
 # methods that return XML
 client.query_day_ahead_prices(country_code, start, end)
-client.query_net_position_dayahead(country_code, start, end)
+client.query_net_position(country_code, start, end, dayahead=True)
 client.query_load(country_code, start, end)
 client.query_load_forecast(country_code, start, end)
 client.query_wind_and_solar_forecast(country_code, start, end, psr_type=None)
@@ -94,7 +94,7 @@ type_marketagreement_type = 'A01'
 
 # methods that return Pandas Series
 client.query_day_ahead_prices(country_code, start=start,end=end)
-client.query_net_position_dayahead(country_code, start=start, end=end)
+client.query_net_position(country_code, start=start, end=end, dayahead=True)
 client.query_crossborder_flows(country_code_from, country_code_to, start, end)
 client.query_scheduled_exchanges(country_code_from, country_code_to, start, end, dayahead=False)
 client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to, start, end)

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -171,14 +171,15 @@ class EntsoeRawClient:
         response = self._base_request(params=params, start=start, end=end)
         return response.text
     
-    def query_net_position_dayahead(self, country_code: Union[Area, str],
-                            start: pd.Timestamp, end: pd.Timestamp) -> str:
+    def query_net_position(self, country_code: Union[Area, str],
+                           start: pd.Timestamp, end: pd.Timestamp, dayahead: bool = True) -> str:
         """
         Parameters
         ----------
         country_code : Area|str
         start : pd.Timestamp
         end : pd.Timestamp
+        dayahead : bool
 
         Returns
         -------
@@ -192,6 +193,9 @@ class EntsoeRawClient:
             'in_Domain': area.code,
             'out_Domain': area.code
         }
+        if not dayahead:
+            params.update({'Contract_MarketAgreement.Type': "A07"})
+
         response = self._base_request(params=params, start=start, end=end)
         return response.text
 
@@ -929,8 +933,8 @@ class EntsoeRawClient:
 
 class EntsoePandasClient(EntsoeRawClient):
     @year_limited
-    def query_net_position_dayahead(self, country_code: Union[Area, str],
-                            start: pd.Timestamp, end: pd.Timestamp) -> pd.Series:
+    def query_net_position(self, country_code: Union[Area, str],
+                            start: pd.Timestamp, end: pd.Timestamp, dayahead: bool = True) -> pd.Series:
         """
 
         Parameters
@@ -944,8 +948,8 @@ class EntsoePandasClient(EntsoeRawClient):
 
         """
         area = lookup_area(country_code)
-        text = super(EntsoePandasClient, self).query_net_position_dayahead(
-            country_code=area, start=start, end=end)
+        text = super(EntsoePandasClient, self).query_net_position(
+            country_code=area, start=start, end=end, dayahead=dayahead)
         series = parse_netpositions(text)
         series = series.tz_convert(area.tz)
         series = series.truncate(before=start, after=end)

--- a/tests.py
+++ b/tests.py
@@ -32,7 +32,7 @@ class EntsoeRawClientTest(unittest.TestCase):
             self.client.query_installed_generation_capacity,
             # this one gives back a zip so disabled for testing right now
             #self.client.query_imbalance_prices,
-            self.client.query_net_position_dayahead
+            self.client.query_net_position
         ]
         for query in queries:
             text = query(country_code=self.country_code, start=self.start,
@@ -93,7 +93,7 @@ class EntsoePandasClientTest(EntsoeRawClientTest):
         queries = [
             self.client.query_day_ahead_prices,
             self.client.query_generation_forecast,
-            self.client.query_net_position_dayahead
+            self.client.query_net_position
         ]
         for query in queries:
             ts = query(country_code=self.country_code, start=self.start,


### PR DESCRIPTION
In #112 a query for the day ahead net position was added. I have adapted the query so that the parameter `dayahead` can be used to select between dayahead net positions and intraday net positions (similiar to scheduled exchanges). The name of the query changed from `query_net_position_dayahead(country_code, start, end)` changed to `query_net_position(country_code, start, end, dayahead=True`