### PR TITLE
Added query for explicit/implicit allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ country_code = 'BE'  # Belgium
 country_code_from = 'FR'  # France
 country_code_to = 'DE_LU' # Germany-Luxembourg
 type_marketagreement_type = 'A01'
+contract_marketagreement_type = 'A01'
 
 # methods that return XML
 client.query_day_ahead_prices(country_code, start, end)
@@ -42,6 +43,7 @@ client.query_net_transfer_capacity_weekahead(country_code_from, country_code_to,
 client.query_net_transfer_capacity_monthahead(country_code_from, country_code_to, start, end)
 client.query_net_transfer_capacity_yearahead(country_code_from, country_code_to, start, end)
 client.query_intraday_offered_capacity(country_code_from, country_code_to, start, end, implicit=True)
+client.query_offered_capacity(country_code_from, country_code_to, start, end, contract_marketagreement_type, implicit=True)
 client.query_contracted_reserve_prices(country_code, start, end, type_marketagreement_type, psr_type=None)
 client.query_contracted_reserve_amount(country_code, start, end, type_marketagreement_type, psr_type=None)
 client.query_procured_balancing_capacity(country_code, start, end, process_type, type_marketagreement_type=None)
@@ -91,6 +93,7 @@ country_code = 'BE'  # Belgium
 country_code_from = 'FR'  # France
 country_code_to = 'DE_LU' # Germany-Luxembourg
 type_marketagreement_type = 'A01'
+contract_marketagreement_type = "A01"
 
 # methods that return Pandas Series
 client.query_day_ahead_prices(country_code, start=start,end=end)
@@ -102,6 +105,7 @@ client.query_net_transfer_capacity_weekahead(country_code_from, country_code_to,
 client.query_net_transfer_capacity_monthahead(country_code_from, country_code_to, start, end)
 client.query_net_transfer_capacity_yearahead(country_code_from, country_code_to, start, end)
 client.query_intraday_offered_capacity(country_code_from, country_code_to, start, end,implicit=True)
+client.query_offered_capacity(country_code_from, country_code_to, start, end, contract_marketagreement_type, implicit=True)
 
 # methods that return Pandas DataFrames
 client.query_load(country_code, start=start,end=end)

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -583,12 +583,17 @@ class EntsoeRawClient:
         -------
         str
         """
+        if implicit:
+            business_type = None
+        else:
+            business_type = "B05"
         return self._query_crossborder(
             country_code_from=country_code_from,
             country_code_to=country_code_to, start=start, end=end,
-            doctype="A25", contract_marketagreement_type=contract_marketagreement_type,
-            auction_type=("A01" if implicit==True else "A02"),
-            business_type="B05")
+            doctype=("A31" if implicit else "A25"),
+            contract_marketagreement_type=contract_marketagreement_type,
+            auction_type=("A01" if implicit else "A02"),
+            business_type=business_type)
 
     def _query_crossborder(
             self, country_code_from: Union[Area, str],


### PR DESCRIPTION
Currently, only a query of the Explicit/Implicit Allocations Intraday OC Evolution is possible using `query_intraday_offered_capacity`. With the new function `query_offered_capacity` queries for Explicit/Implicit Allocations Intraday and Day ahead, and Explicit Allocations Long Term / Medium Term (Weekly, Monthly, Yearly) are also possible.