### PR TITLE
add paginated and documents_limited decorator to query_offered_capacity

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1443,11 +1443,13 @@ class EntsoePandasClient(EntsoeRawClient):
         return ts
 
     @year_limited
+    @paginated
+    @documents_limited(100)
     def query_offered_capacity(
-        self, country_code_from: Union[Area, str],
+            self, country_code_from: Union[Area, str],
             country_code_to: Union[Area, str], start: pd.Timestamp,
             end: pd.Timestamp, contract_marketagreement_type: str,
-            implicit:bool = True,**kwargs) -> pd.Series:
+            implicit: bool = True, offset: int = 0, **kwargs) -> pd.Series:
         """
         Allocated result documents, for OC evolution see query_intraday_offered_capacity
         Note: Result will be in the timezone of the origin country  --> to check
@@ -1461,6 +1463,8 @@ class EntsoePandasClient(EntsoeRawClient):
         contract_marketagreement_type : str
             type of contract (see mappings.MARKETAGREEMENTTYPE)
         implicit: bool (True = implicit - default for most borders. False = explicit - for instance BE-GB)
+        offset: int
+            offset for querying more than 100 documents
         Returns
         -------
         pd.Series
@@ -1473,7 +1477,8 @@ class EntsoePandasClient(EntsoeRawClient):
             start=start,
             end=end,
             contract_marketagreement_type=contract_marketagreement_type,
-            implicit=implicit)
+            implicit=implicit,
+            offset=offset)
         ts = parse_crossborder_flows(text)
         ts = ts.tz_convert(area_from.tz)
         ts = ts.truncate(before=start, after=end)


### PR DESCRIPTION
In #169 decorators for `paginated` and `documents_limited(100)` are missing. The following code requests for 144 documents and therefore a PaginationError is raised. To avoid this, the decorators are added.

```
start = pd.Timestamp('20190801', tz='Europe/Berlin')
end = pd.Timestamp('20190802', tz='Europe/Berlin')
client.query_offered_capacity(country_code_from="AT", country_code_to="SI", start=start, end=end, contract_marketagreement_type="A07", implicit=False)
```