### PR TITLE
Add MRID and revision number for unavailabilities

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -772,6 +772,8 @@ _INV_BIDDING_ZONE_DICO = {area.code: area.name for area in Area}
 
 HEADERS_UNAVAIL_GEN = ['created_doc_time',
                        'docstatus',
+                       'mrid',
+                       'revision',
                        'businesstype',
                        'biddingzone_domain',
                        'qty_uom',
@@ -824,6 +826,8 @@ def _unavailability_gen_ts(soup: bs4.BeautifulSoup) -> list:
 
 HEADERS_UNAVAIL_TRANSM = ['created_doc_time',
                           'docstatus',
+                          'mrid',
+                          'revision',
                           'businesstype',
                           'in_domain',
                           'out_domain',
@@ -907,6 +911,8 @@ def _outage_parser(xml_file: bytes, headers, ts_func) -> pd.DataFrame:
     xml_text = xml_file.decode()
 
     soup = bs4.BeautifulSoup(xml_text, 'html.parser')
+    mrid = soup.find("mrid").text
+    revision_number = int(soup.find("revisionnumber").text)
     try:
         creation_date = pd.Timestamp(soup.createddatetime.text)
     except AttributeError:
@@ -919,7 +925,7 @@ def _outage_parser(xml_file: bytes, headers, ts_func) -> pd.DataFrame:
     d = list()
     series = _extract_timeseries(xml_text)
     for ts in series:
-        row = [creation_date, docstatus]
+        row = [creation_date, docstatus, mrid, revision_number]
         for t in ts_func(ts):
             d.append(row + t)
     df = pd.DataFrame.from_records(d, columns=headers)

--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -826,8 +826,6 @@ def _unavailability_gen_ts(soup: bs4.BeautifulSoup) -> list:
 
 HEADERS_UNAVAIL_TRANSM = ['created_doc_time',
                           'docstatus',
-                          'mrid',
-                          'revision',
                           'businesstype',
                           'in_domain',
                           'out_domain',


### PR DESCRIPTION
Adds MRID and revision number unavailabilities as it is part of the primary key for these entries (thus allowing their identification)