### PR TITLE
use keyword-only params in sort_index

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1911,7 +1911,7 @@ class EntsoePandasClient(EntsoeRawClient):
         df = df.tz_convert(area.tz)
         # Truncation will fail if data is not sorted along the index in rare
         # cases. Ensure the dataframe is sorted:
-        df = df.sort_index(0)
+        df = df.sort_index(axis=0)
         df = df.truncate(before=start, after=end)
         return df
 


### PR DESCRIPTION
in methods where inplace is allowed, non-keyword args will become deprecated soon:
https://github.com/pandas-dev/pandas/pull/41506

This does not change any current behavior, but removes a deprecation warning when using the latest pandas version