### PR TITLE
Relax pandas requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 pytz
 beautifulsoup4
-pandas>=1.4.0
+pandas

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed.
-    install_requires=['requests', 'pytz', 'beautifulsoup4', 'pandas>=1.4.0'],
+    install_requires=['requests', 'pytz', 'beautifulsoup4', 'pandas'],
 
     include_package_data=True,
 )


### PR DESCRIPTION
Rather simple solution to relax the pandas requirements.

Why:  
Many companies prefer to allow packages supplied by the distro. Fedora 35 (and 36) currently have pandas version 1.3.5 as the supported pandas package. The current PR would support also lower pandas versions.
