### PR TITLE
fix: round timestamps to nearest hour before truncation

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -151,7 +151,7 @@ class EntsoeRawClient:
         if dtm.tzinfo is not None and dtm.tzinfo != pytz.UTC:
             dtm = dtm.tz_convert("UTC")
         fmt = '%Y%m%d%H00'
-        ret_str = dtm.strftime(fmt)
+        ret_str = dtm.round(freq='h').strftime(fmt)
         return ret_str
 
     def query_day_ahead_prices(self, country_code: Union[Area, str],


### PR DESCRIPTION
Fixes https://github.com/EnergieID/entsoe-py/issues/217, this approach allows for data access for requests <60mins.