### PR TITLE
Fixing the issue #234: documents_limited decorator removes data after concatenating by removing "duplicates"

### DIFF
--- a/entsoe/exceptions.py
+++ b/entsoe/exceptions.py
@@ -16,3 +16,7 @@ class InvalidBusinessParameterError(Exception):
 
 class InvalidParameterError(Exception):
     pass
+
+
+class InvalidDataReturnedWarning(UserWarning):
+    pass


### PR DESCRIPTION
The issue #234 explains a problem that the merging on the decorators has been buggy and should be fixed.

This PR proposes one solution and creates a unit test that fails when the old code is used, and succeeds when the new code is used.

Please let me know together with issue #234 needs more explaination.