### PR TITLE
Fix: add mrid and revision to HEADERS_UNAVAIL_TRANSM

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -884,6 +884,8 @@ def _unavailability_gen_ts(soup: bs4.BeautifulSoup) -> list:
 
 HEADERS_UNAVAIL_TRANSM = ['created_doc_time',
                           'docstatus',
+                          'mrid',
+                          'revision'
                           'businesstype',
                           'in_domain',
                           'out_domain',


### PR DESCRIPTION
Fixes #254
Fixes #219 

Adding back `mrid` and `revision` into `HEADERS_UNAVAIL_TRANSM`.