### PR TITLE
Missing Comma in HEADERS_UNAVAIL_TRANSM list definition

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -892,7 +892,7 @@ def _unavailability_gen_ts(soup: bs4.BeautifulSoup) -> list:
 HEADERS_UNAVAIL_TRANSM = ['created_doc_time',
                           'docstatus',
                           'mrid',
-                          'revision'
+                          'revision',
                           'businesstype',
                           'in_domain',
                           'out_domain',


### PR DESCRIPTION
The missing comma between revision and business type, was causing a string concatenation, naming a merged header "revisionbusinesstype", instead of two headers "revision" and "businesstype", thus crashing afterwards, because the headers length was one less than the contents width.