### PR TITLE
Remove mention of 17.1.E in the docstring.

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -813,7 +813,6 @@ class EntsoeRawClient:
             end: pd.Timestamp, process_type: str,
             type_marketagreement_type: Optional[str] = None) -> bytes:
         """
-        Activated Balancing Energy [17.1.E]
         Parameters
         ----------
         country_code : Area|str
@@ -1794,7 +1793,6 @@ class EntsoePandasClient(EntsoeRawClient):
             end: pd.Timestamp,
             type_marketagreement_type: Optional[str] = None) -> bytes:
         """
-        Activated Balancing Energy [17.1.E]
         Parameters
         ----------
         country_code : Area|str


### PR DESCRIPTION
The function query_procured_balancing_capacity states in its docstring that it returns the activated() balancing energy 17.1.E which it does not. This seems like a copy-paste error from query_activated_balancing_energy() which actually returns 17.1.E

As I don't know what query_procured_balancing_capacity() actually returns, I cannot make a more meaningful docstring. If somebody knows what DocumentType A15 "Acquiring system operator reserve schedule" is, it would be great to update the docstring accordingly.