### PR TITLE
+if clause for _query_imbalance in decorators

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -379,7 +379,9 @@ def _parse_aggregated_bids_timeseries(soup):
     
     for dt, point in zip(tx, points):
         df.loc[dt, 'Offered'] = float(point.find('quantity').text)
-        df.loc[dt, 'Activated'] = float(point.find('secondaryquantity').text)
+        activated = point.find('secondaryquantity')
+        if activated is not None:
+            df.loc[dt, 'Activated'] = float(activated.text)
 
     mr_id = int(soup.find('mrid').text)
     df.columns = pd.MultiIndex.from_product(


### PR DESCRIPTION
This fixes the issue that unavailability entries are discarded because of duplicate removal in the decorators by adding an if-clause to restrict duplicate removal to all wrapped functions other than _query_imbalance.

To test, try the following code with and without this change:
```python
from entsoe import EntsoePandasClient
import pandas as pd
import pytz
import os

start = pd.Timestamp(2024, 1, 1, tzinfo=pytz.timezone('Europe/Berlin'))
end = pd.Timestamp(2024, 1, 14, tzinfo=pytz.timezone('Europe/Berlin'))

client = EntsoePandasClient(api_key=os.getenv('ENTSOE_API_KEY'))
df = client.query_unavailability_of_generation_units('DE_LU', start=start,end=end, docstatus='A05')
```

Also fixes an issue with the aggregated_bids parsing function for querying TSO data that does not include activated volumes.