### PR TITLE
Bugfix: Use pd.concat instead of deprecated pd.Series.append

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -96,9 +96,9 @@ def parse_loads(xml_text, process_type='A01'):
         for soup in _extract_timeseries(xml_text):
             t = _parse_load_timeseries(soup)
             if soup.find('businesstype').text == 'A60':
-                series_min = series_min.append(t)
+                series_min = pd.concat([series_min, t])
             elif soup.find('businesstype').text == 'A61':
-                series_max = series_max.append(t)
+                series_max = pd.concat([series_max, t])
             else:
                 continue
         return pd.DataFrame({


### PR DESCRIPTION
The PR fixes a bug in the `parse_loads` method, where an deprecated function of pandas was still used. parse_loads can therefore currently not be used.

entsoe-py is using pandas>=2.2.0 per reqiurements.txt. The append-method for DataFrame and Series was deprecated in 2.0.0 (see [here (pandas change notes)](https://pandas.pydata.org/pandas-docs/version/2.2.0rc0/whatsnew/v2.0.0.html) or [here (GH issue)](https://github.com/pandas-dev/pandas/issues/35407)).

This PR changes the use of append to the now recommended concat method.