### PR TITLE
Prepared Day-ahead prices request for use in Async Frameworks

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1231,14 +1231,13 @@ class EntsoePandasClient(EntsoeRawClient):
             start=start-pd.Timedelta(days=1),
             end=end+pd.Timedelta(days=1)
         )
-        series = parse_prices(text)[resolution]
-        if len(series) == 0:
-            raise NoMatchingDataError
-        series = series.tz_convert(area.tz)
-        series = series.truncate(before=start, after=end)
-        # because of the above fix we need to check again if any valid data exists after truncating
-        if len(series) == 0:
-            raise NoMatchingDataError
+        series = parse_prices(
+            xml_text=text,
+            tz=area.tz,
+            resolution=resolution,
+            start=start,
+            end=end
+        )
         return series
 
     @year_limited

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -82,7 +82,7 @@ class EntsoeRawClient:
         -------
         requests.Response
         """
-        prepared_request = self.prepare_base_request(params=params, start=start, end=end)
+        prepared_request = self._prepare_base_request(params=params, start=start, end=end)
         return self._do_prepared_request(prepared_request)
         
     def _do_prepared_request(self, prepared_request: requests.PreparedRequest) -> requests.Response:
@@ -136,7 +136,7 @@ class EntsoeRawClient:
                     raise NoMatchingDataError
             return response
         
-    def prepare_base_request(self, params: Dict, start: pd.Timestamp,
+    def _prepare_base_request(self, params: Dict, start: pd.Timestamp,
                              end: pd.Timestamp) -> requests.PreparedRequest:
         """
         Parameters
@@ -224,7 +224,7 @@ class EntsoeRawClient:
                 'in_Domain': area.code,
                 'out_Domain': area.code
           }
-          return self.prepare_base_request(params=params, start=start, end=end)
+          return self._prepare_base_request(params=params, start=start, end=end)
 
     def query_aggregated_bids(self, country_code: Union[Area, str],
                               process_type: str,


### PR DESCRIPTION
As proposed in #315.

This PR introduces a method that **Prepares** the day-ahead prices request, without sending it. This allows you to defer the handling of that request to another system.
Next, I have isolated the parsing of the pricing response, so it can also be used in a stand-alone way.

Here's an example of how you could use this to request data using `aiohttp`:

```python
import aiohttp
import pandas as pd

from entsoe import EntsoePandasClient
from entsoe.mappings import lookup_area
from entsoe.parsers import parse_prices

from settings import api_key

client = EntsoePandasClient(api_key=api_key)

start = pd.Timestamp('2024-01-01', tz='Europe/Brussels')
end = pd.Timestamp('2024-01-02', tz='Europe/Brussels')
area = lookup_area('BE')

prepared_request = client.prepare_query_day_ahead_prices(country_code=area, start=start, end=end)

async with aiohttp.ClientSession() as session:
    response = await session._request(
        method='GET',
        str_or_url=prepared_request.url
    )
    response.raise_for_status()
    text = await response.text()

series = parse_prices(
    xml_text=text,
    tz=area.tz,
    resolution='60min',
    start=start,
    end=end
)
```