### PR TITLE
+mRID parameter for query_unavailability

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -945,6 +945,7 @@ class EntsoeRawClient:
             end: pd.Timestamp, doctype: str, docstatus: Optional[str] = None,
             periodstartupdate: Optional[pd.Timestamp] = None,
             periodendupdate: Optional[pd.Timestamp] = None,
+            mRID=None,
             offset: int = 0) -> bytes:
         """
         Generic unavailibility query method.
@@ -979,6 +980,8 @@ class EntsoeRawClient:
             params['periodStartUpdate'] = self._datetime_to_str(
                 periodstartupdate)
             params['periodEndUpdate'] = self._datetime_to_str(periodendupdate)
+        if mRID:
+            params['mRID'] = mRID
         response = self._base_request(params=params, start=start, end=end)
         return response.content
 
@@ -987,6 +990,7 @@ class EntsoeRawClient:
             end: pd.Timestamp, docstatus: Optional[str] = None,
             periodstartupdate: Optional[pd.Timestamp] = None,
             periodendupdate: Optional[pd.Timestamp] = None,
+            mRID = None,
             offset: int = 0) -> bytes:
         """
         This endpoint serves ZIP files.
@@ -1010,14 +1014,15 @@ class EntsoeRawClient:
         content = self._query_unavailability(
             country_code=country_code, start=start, end=end, doctype="A80",
             docstatus=docstatus, periodstartupdate=periodstartupdate,
-            periodendupdate=periodendupdate, offset=offset)
+            periodendupdate=periodendupdate, mRID=mRID, offset=offset)
         return content
 
     def query_unavailability_of_production_units(
             self, country_code: Union[Area, str], start: pd.Timestamp,
             end: pd.Timestamp, docstatus: Optional[str] = None,
             periodstartupdate: Optional[pd.Timestamp] = None,
-            periodendupdate: Optional[pd.Timestamp] = None) -> bytes:
+            periodendupdate: Optional[pd.Timestamp] = None,
+            mRID: Optional[str] = None) -> bytes:
         """
         This endpoint serves ZIP files.
         The query is limited to 200 items per request.
@@ -1038,7 +1043,8 @@ class EntsoeRawClient:
         content = self._query_unavailability(
             country_code=country_code, start=start, end=end, doctype="A77",
             docstatus=docstatus, periodstartupdate=periodstartupdate,
-            periodendupdate=periodendupdate)
+            periodendupdate=periodendupdate,
+            mRID = mRID)
         return content
 
     def query_unavailability_transmission(
@@ -1088,7 +1094,7 @@ class EntsoeRawClient:
 
     def query_withdrawn_unavailability_of_generation_units(
             self, country_code: Union[Area, str], start: pd.Timestamp,
-            end: pd.Timestamp) -> bytes:
+            end: pd.Timestamp, mRID: Optional[str] = None) -> bytes:
         """
         Parameters
         ----------
@@ -1102,7 +1108,7 @@ class EntsoeRawClient:
         """
         content = self._query_unavailability(
             country_code=country_code, start=start, end=end,
-            doctype="A80", docstatus='A13')
+            doctype="A80", docstatus='A13', mRID=mRID)
         return content
 
 class EntsoePandasClient(EntsoeRawClient):
@@ -1930,6 +1936,7 @@ class EntsoePandasClient(EntsoeRawClient):
             end: pd.Timestamp, doctype: str, docstatus: Optional[str] = None,
             periodstartupdate: Optional[pd.Timestamp] = None,
             periodendupdate: Optional[pd.Timestamp] = None,
+            mRID: Optional[str] = None,
             offset: int = 0) -> pd.DataFrame:
         """
         Parameters
@@ -1951,7 +1958,7 @@ class EntsoePandasClient(EntsoeRawClient):
         content = super(EntsoePandasClient, self)._query_unavailability(
             country_code=area, start=start, end=end, doctype=doctype,
             docstatus=docstatus, periodstartupdate=periodstartupdate,
-            periodendupdate=periodendupdate, offset=offset)
+            periodendupdate=periodendupdate, mRID=mRID, offset=offset)
         df = parse_unavailabilities(content, doctype)
         df = df.tz_convert(area.tz)
         df['start'] = df['start'].apply(lambda x: x.tz_convert(area.tz))
@@ -1963,7 +1970,8 @@ class EntsoePandasClient(EntsoeRawClient):
             self, country_code: Union[Area, str], start: pd.Timestamp,
             end: pd.Timestamp, docstatus: Optional[str] = None,
             periodstartupdate: Optional[pd.Timestamp] = None,
-            periodendupdate: Optional[pd.Timestamp] = None) -> pd.DataFrame:
+            periodendupdate: Optional[pd.Timestamp] = None, 
+            mRID = None) -> pd.DataFrame:
         """
         Parameters
         ----------
@@ -1981,14 +1989,15 @@ class EntsoePandasClient(EntsoeRawClient):
         df = self._query_unavailability(
             country_code=country_code, start=start, end=end, doctype="A80",
             docstatus=docstatus, periodstartupdate=periodstartupdate,
-            periodendupdate=periodendupdate)
+            periodendupdate=periodendupdate, mRID=mRID)
         return df
 
     def query_unavailability_of_production_units(
             self, country_code: Union[Area, str], start: pd.Timestamp,
             end: pd.Timestamp, docstatus: Optional[str] = None,
             periodstartupdate: Optional[pd.Timestamp] = None,
-            periodendupdate: Optional[pd.Timestamp] = None) -> pd.DataFrame:
+            periodendupdate: Optional[pd.Timestamp] = None,
+            mRID: Optional[str] = None) -> pd.DataFrame:
         """
         Parameters
         ----------
@@ -2006,7 +2015,7 @@ class EntsoePandasClient(EntsoeRawClient):
         df = self._query_unavailability(
             country_code=country_code, start=start, end=end, doctype="A77",
             docstatus=docstatus, periodstartupdate=periodstartupdate,
-            periodendupdate=periodendupdate)
+            periodendupdate=periodendupdate, mRID=mRID)
         return df
 
     @paginated


### PR DESCRIPTION
Added mRID as a parameter to the query_unavailability functions to enable users to fetch previous revisions of documents.
This is required when you want to know, when the unavailability was first disclosed by a market participant.
It works by first querying current unavailabilities and then querying again with the mRID of the document of interest that has more than one revision.

Here's a code snippet to test it:
```python
from entsoe import EntsoePandasClient
import pandas as pd
import pytz
import os

# Initialize client 
client = EntsoePandasClient(api_key=os.getenv("ENTSOE_API_KEY"))

# Get generation unavailabilites in first week of May
generation_current = client.query_unavailability_of_generation_units(
        'DE_LU', 
        docstatus="A05",
        start=pd.Timestamp(2024, 3, 1, tz=pytz.timezone('Europe/Berlin')), 
        end=pd.Timestamp(2024, 3, 8, tz=pytz.timezone('Europe/Berlin')),
    )
# Get mRID of a document with at least 2 revisions
generation_mrid = generation_current[generation_current["revision"] > 1].mrid[0]
# Get all versions of this document
generation_revisions = client.query_unavailability_of_generation_units(
        'DE_LU', 
        start=pd.Timestamp(2024, 3, 1, tz=pytz.timezone('Europe/Berlin')), 
        end=pd.Timestamp(2024, 3, 8, tz=pytz.timezone('Europe/Berlin')),
        mRID=generation_mrid
    )

# Get production unavailabilites in first week of May
production_current = client.query_unavailability_of_production_units(
        'DE_LU', 
        docstatus="A05",
        start=pd.Timestamp(2024, 3, 1, tz=pytz.timezone('Europe/Berlin')), 
        end=pd.Timestamp(2024, 3, 8, tz=pytz.timezone('Europe/Berlin')),
    )

# Get mRID of a document with at least 2 revisions
production_mrid = production_current[production_current["revision"] > 1].mrid[0]
# Get all versions of this document
production_revisions = client.query_unavailability_of_production_units(
        'DE_LU', 
        start=pd.Timestamp(2024, 3, 1, tz=pytz.timezone('Europe/Berlin')), 
        end=pd.Timestamp(2024, 3, 8, tz=pytz.timezone('Europe/Berlin')),
        mRID=production_mrid
    )
```