### PR TITLE
Add missing mapping from HU to Slovenia

### DIFF
--- a/entsoe/mappings.py
+++ b/entsoe/mappings.py
@@ -283,7 +283,7 @@ NEIGHBOURS = {
     'CZ': ['AT', 'DE_AT_LU', 'DE_LU', 'PL', 'SK'],
     'GB': ['BE', 'FR', 'IE_SEM', 'NL', 'NO_2', 'DK_1'],
     'NO_2': ['DE_LU', 'DK_1', 'NL', 'NO_1', 'NO_5', 'GB'],
-    'HU': ['AT', 'HR', 'RO', 'RS', 'SK', 'UA'],
+    'HU': ['AT', 'HR', 'RO', 'RS', 'SI', 'SK', 'UA'],
     'IT_NORD': ['CH', 'DE_AT_LU', 'FR', 'SI', 'AT', 'IT_CNOR'],
     'ES': ['FR', 'PT'],
     'SI': ['AT', 'DE_AT_LU', 'HR', 'IT_NORD'],


### PR DESCRIPTION
As you can check on the [Hungarian TSO page](https://www.mavir.hu/web/mavir-en) or via the API, Hungary is trading with Slovenia and there are imports/export on this direction.

Our `NEIGHBOURS` mapping is missing that.