### PR TITLE
Fixes a FutureWarning regarding pandas freq values

### DIFF
--- a/entsoe/series_parsers.py
+++ b/entsoe/series_parsers.py
@@ -24,12 +24,12 @@ def _resolution_to_timedelta(res_text: str) -> str:
     """
     resolutions = {
         'PT60M': '60min',
-        'P1Y': '12M',
+        'P1Y': '12ME',
         'PT15M': '15min',
         'PT30M': '30min',
         'P1D': '1D',
         'P7D': '7D',
-        'P1M': '1M',
+        'P1M': '1ME',
     }
     delta = resolutions.get(res_text)
     if delta is None:


### PR DESCRIPTION
This produced `FutureWarning: 'M' is deprecated and will be removed in a future version, please use 'ME' instead`, which is fixed with this PR.

As we are using pandas version >=2.2.0 anyway, we can change this without raising the requirements. 

A list of possible values is given here:
https://pandas.pydata.org/pandas-docs/version/2.2/user_guide/timeseries.html#offset-aliases