### PR TITLE
Consider points of varying quantity in availability

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -941,7 +941,7 @@ def _available_period(timeseries: bs4.BeautifulSoup) -> list:
         start_p, end_p = pd.Timestamp(period.timeinterval.start.text), pd.Timestamp(
             period.timeinterval.end.text)
         res = period.resolution.text
-        pts = timeseries.find_all('point')
+        pts = period.find_all('point')
         for idx, pt in enumerate(pts):
             pstn, qty = pt.position.text, pt.quantity.text
             start = start_p + (pd.Timedelta(res) * (int(pstn) - 1))


### PR DESCRIPTION
For availability current parsing only considers `start` and `end` of `timeInterval` in the given `Available_Period` per document. However, for some outages, the period is split up to multiple points, which indicate varying `quantity` during the period. 
As an example ([full file](https://github.com/user-attachments/files/15914378/218-218-PLANNED_UNAVAIL_OF_GENERATION_UNITS_202302270700-202303070600.zip)):
```
...
            <Available_Period>
                <timeInterval>
                    <start>2023-02-27T06:00Z</start>
                    <end>2023-03-07T05:00Z</end>
                </timeInterval>
                <resolution>PT15M</resolution>
                    <Point>
                        <position>1</position>
                        <quantity>547.5</quantity>
                    </Point>
                    <Point>
                        <position>121</position>
                        <quantity>365</quantity>
                    </Point>
                    <Point>
                        <position>137</position>
                        <quantity>547.5</quantity>
                    </Point>
            </Available_Period>
...
```
The proposed change extends the existing parser by returning an outage period for each point instead of the period as a whole.