### PR TITLE
fix(crossborder): correct position to datetime mapping in flows parser

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -796,9 +796,18 @@ def _parse_crossborder_flows_timeseries(soup):
         positions.append(int(point.find('position').text))
         flows.append(float(point.find('quantity').text))
 
+    # Create series with numeric position index
     series = pd.Series(index=positions, data=flows)
     series = series.sort_index()
-    series.index = _parse_datetimeindex(soup)
+
+    # Get datetime index
+    datetime_index = _parse_datetimeindex(soup)
+
+    # Map position numbers to datetime points
+    series.index = [datetime_index[pos - 1] for pos in series.index]
+
+    # Reindex to full datetime range to ensure all points exist
+    series = series.reindex(datetime_index)
 
     return series
 


### PR DESCRIPTION
Fix missing values in crossborder flows timeseries by properly mapping position numbers (1-based) to datetime index points (0-based) in _parse_crossborder_flows_timeseries.

Before: Exception raised
After: Values correctly mapped to their timestamps, with NaN only for truly missing periods

Part of ENTSO-E Transparency data ingestion service.