### PR TITLE
fix: Fix type hint EntsoePandasClient.query_aggregated_bids

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1186,7 +1186,7 @@ class EntsoePandasClient(EntsoeRawClient):
     @year_limited
     def query_aggregated_bids(self, country_code: Union[Area, str],
                               process_type: str,
-                            start: pd.Timestamp, end: pd.Timestamp) -> pd.Series:
+                              start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame:
         """
 
         Parameters


### PR DESCRIPTION
**Problem**

According to type hints EntsoePandasClient.query_aggregated_bids method should return a pd.Series, but in reality it returns a pd.DataFrame

**Solution**

Fix type hint