### PR TITLE
Add support for python3.12

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 warnings.filterwarnings('ignore', category=XMLParsedAsHTMLWarning)
 
 __title__ = "entsoe-py"
-__version__ = "0.6.18"
+__version__ = "0.6.19"
 __author__ = "EnergieID.be, Frank Boerman"
 __license__ = "MIT"
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11'
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12'
     ],
 
     keywords='ENTSO-E data api energy',


### PR DESCRIPTION
Add support for python 3.12.

Local tests passed successfully. API key-dependent tests were not performed as no API key was available for me.