### PR TITLE
Add `eic_code` parameter to filter on single generation unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,20 @@ The package comes with 2 clients:
 - [`EntsoeRawClient`](#EntsoeRawClient): Returns data in its raw format, usually XML or a ZIP-file containing XML's
 - [`EntsoePandasClient`](#EntsoePandasClient): Returns data parsed as a Pandas Series or DataFrame
 ### <a name="EntsoeRawClient"></a>EntsoeRawClient
+
 ```python
 from entsoe import EntsoeRawClient
 import pandas as pd
 
-client = EntsoeRawClient(api_key=<YOUR API KEY>)
+client = EntsoeRawClient(api_key= < YOUR
+API
+KEY >)
 
 start = pd.Timestamp('20171201', tz='Europe/Brussels')
 end = pd.Timestamp('20180101', tz='Europe/Brussels')
 country_code = 'BE'  # Belgium
 country_code_from = 'FR'  # France
-country_code_to = 'DE_LU' # Germany-Luxembourg
+country_code_to = 'DE_LU'  # Germany-Luxembourg
 type_marketagreement_type = 'A01'
 contract_marketagreement_type = 'A01'
 process_type = 'A51'
@@ -32,33 +35,63 @@ client.query_net_position(country_code, start, end, dayahead=True)
 client.query_load(country_code, start, end)
 client.query_load_forecast(country_code, start, end)
 client.query_wind_and_solar_forecast(country_code, start, end, psr_type=None)
-client.query_intraday_wind_and_solar_forecast(country_code, start, end, psr_type=None)
+client.query_intraday_wind_and_solar_forecast(country_code, start, end,
+                                              psr_type=None)
 client.query_generation_forecast(country_code, start, end)
 client.query_generation(country_code, start, end, psr_type=None)
-client.query_generation_per_plant(country_code, start, end, psr_type=None)
-client.query_installed_generation_capacity(country_code, start, end, psr_type=None)
-client.query_installed_generation_capacity_per_unit(country_code, start, end, psr_type=None)
+client.query_generation_per_plant(country_code, start, end, psr_type=None,
+                                  eic_code=None)
+client.query_installed_generation_capacity(country_code, start, end,
+                                           psr_type=None)
+client.query_installed_generation_capacity_per_unit(country_code, start, end,
+                                                    psr_type=None)
 client.query_crossborder_flows(country_code_from, country_code_to, start, end)
-client.query_scheduled_exchanges(country_code_from, country_code_to, start, end, dayahead=False)
-client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to, start, end)
-client.query_net_transfer_capacity_weekahead(country_code_from, country_code_to, start, end)
-client.query_net_transfer_capacity_monthahead(country_code_from, country_code_to, start, end)
-client.query_net_transfer_capacity_yearahead(country_code_from, country_code_to, start, end)
-client.query_intraday_offered_capacity(country_code_from, country_code_to, start, end, implicit=True)
-client.query_offered_capacity(country_code_from, country_code_to, start, end, contract_marketagreement_type, implicit=True)
-client.query_contracted_reserve_prices(country_code, start, end, type_marketagreement_type, psr_type=None)
-client.query_contracted_reserve_prices_procured_capacity(country_code, start, end, process_type type_marketagreement_type, psr_type=None)
-client.query_contracted_reserve_amount(country_code, start, end, type_marketagreement_type, psr_type=None)
-client.query_procured_balancing_capacity(country_code, start, end, process_type, type_marketagreement_type=None)
-client.query_aggregate_water_reservoirs_and_hydro_storage(country_code, start, end)
+client.query_scheduled_exchanges(country_code_from, country_code_to, start,
+                                 end, dayahead=False)
+client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to,
+                                            start, end)
+client.query_net_transfer_capacity_weekahead(country_code_from,
+                                             country_code_to, start, end)
+client.query_net_transfer_capacity_monthahead(country_code_from,
+                                              country_code_to, start, end)
+client.query_net_transfer_capacity_yearahead(country_code_from,
+                                             country_code_to, start, end)
+client.query_intraday_offered_capacity(country_code_from, country_code_to,
+                                       start, end, implicit=True)
+client.query_offered_capacity(country_code_from, country_code_to, start, end,
+                              contract_marketagreement_type, implicit=True)
+client.query_contracted_reserve_prices(country_code, start, end,
+                                       type_marketagreement_type,
+                                       psr_type=None)
+client.query_contracted_reserve_prices_procured_capacity(country_code, start,
+                                                         end, process_type
+type_marketagreement_type, psr_type = None)
+client.query_contracted_reserve_amount(country_code, start, end,
+                                       type_marketagreement_type,
+                                       psr_type=None)
+client.query_procured_balancing_capacity(country_code, start, end,
+                                         process_type,
+                                         type_marketagreement_type=None)
+client.query_aggregate_water_reservoirs_and_hydro_storage(country_code, start,
+                                                          end)
 
 # methods that return ZIP (bytes)
 client.query_imbalance_prices(country_code, start, end, psr_type=None)
-client.query_unavailability_of_generation_units(country_code, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
-client.query_unavailability_of_production_units(country_code, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
-client.query_unavailability_transmission(country_code_from, country_code_to, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
+client.query_unavailability_of_generation_units(country_code, start, end,
+                                                docstatus=None,
+                                                periodstartupdate=None,
+                                                periodendupdate=None)
+client.query_unavailability_of_production_units(country_code, start, end,
+                                                docstatus=None,
+                                                periodstartupdate=None,
+                                                periodendupdate=None)
+client.query_unavailability_transmission(country_code_from, country_code_to,
+                                         start, end, docstatus=None,
+                                         periodstartupdate=None,
+                                         periodendupdate=None)
 client.query_unavailability_of_offshore_grid(area_code, start, end)
-client.query_withdrawn_unavailability_of_generation_units(country_code, start, end)
+client.query_withdrawn_unavailability_of_generation_units(country_code, start,
+                                                          end)
 ```
 #### Dump result to file
 ```python
@@ -89,17 +122,20 @@ The Pandas Client works similar to the Raw Client, with extras:
 
 Please note that this client requires you to specifically set a start= and end= parameter which should be a pandas timestamp with timezone.
 If not it will throw an exception
+
 ```python
 from entsoe import EntsoePandasClient
 import pandas as pd
 
-client = EntsoePandasClient(api_key=<YOUR API KEY>)
+client = EntsoePandasClient(api_key= < YOUR
+API
+KEY >)
 
 start = pd.Timestamp('20171201', tz='Europe/Brussels')
 end = pd.Timestamp('20180101', tz='Europe/Brussels')
 country_code = 'BE'  # Belgium
 country_code_from = 'FR'  # France
-country_code_to = 'DE_LU' # Germany-Luxembourg
+country_code_to = 'DE_LU'  # Germany-Luxembourg
 type_marketagreement_type = 'A01'
 contract_marketagreement_type = "A01"
 process_type = 'A51'
@@ -107,38 +143,73 @@ process_type = 'A51'
 # methods that return Pandas Series
 client.query_day_ahead_prices(country_code, start=start, end=end)
 client.query_net_position(country_code, start=start, end=end, dayahead=True)
-client.query_crossborder_flows(country_code_from, country_code_to, start=start, end=end)
-client.query_scheduled_exchanges(country_code_from, country_code_to, start=start, end=end, dayahead=False)
-client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to, start=start, end=end)
-client.query_net_transfer_capacity_weekahead(country_code_from, country_code_to, start=start, end=end)
-client.query_net_transfer_capacity_monthahead(country_code_from, country_code_to, start=start, end=end)
-client.query_net_transfer_capacity_yearahead(country_code_from, country_code_to, start=start, end=end)
-client.query_intraday_offered_capacity(country_code_from, country_code_to, start=start, end=end, implicit=True)
-client.query_offered_capacity(country_code_from, country_code_to, contract_marketagreement_type, start=start, end=end, implicit=True)
-client.query_aggregate_water_reservoirs_and_hydro_storage(country_code, start=start, end=end)
+client.query_crossborder_flows(country_code_from, country_code_to, start=start,
+                               end=end)
+client.query_scheduled_exchanges(country_code_from, country_code_to,
+                                 start=start, end=end, dayahead=False)
+client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to,
+                                            start=start, end=end)
+client.query_net_transfer_capacity_weekahead(country_code_from,
+                                             country_code_to, start=start,
+                                             end=end)
+client.query_net_transfer_capacity_monthahead(country_code_from,
+                                              country_code_to, start=start,
+                                              end=end)
+client.query_net_transfer_capacity_yearahead(country_code_from,
+                                             country_code_to, start=start,
+                                             end=end)
+client.query_intraday_offered_capacity(country_code_from, country_code_to,
+                                       start=start, end=end, implicit=True)
+client.query_offered_capacity(country_code_from, country_code_to,
+                              contract_marketagreement_type, start=start,
+                              end=end, implicit=True)
+client.query_aggregate_water_reservoirs_and_hydro_storage(country_code,
+                                                          start=start, end=end)
 
 # methods that return Pandas DataFrames
 client.query_load(country_code, start=start, end=end)
 client.query_load_forecast(country_code, start=start, end=end)
 client.query_load_and_forecast(country_code, start=start, end=end)
 client.query_generation_forecast(country_code, start=start, end=end)
-client.query_wind_and_solar_forecast(country_code, start=start, end=end, psr_type=None)
-client.query_intraday_wind_and_solar_forecast(country_code, start=start, end=end, psr_type=None)
+client.query_wind_and_solar_forecast(country_code, start=start, end=end,
+                                     psr_type=None)
+client.query_intraday_wind_and_solar_forecast(country_code, start=start,
+                                              end=end, psr_type=None)
 client.query_generation(country_code, start=start, end=end, psr_type=None)
-client.query_generation_per_plant(country_code, start=start, end=end, psr_type=None, include_eic=False)
-client.query_installed_generation_capacity(country_code, start=start, end=end, psr_type=None)
-client.query_installed_generation_capacity_per_unit(country_code, start=start, end=end, psr_type=None)
-client.query_imbalance_prices(country_code, start=start, end=end, psr_type=None)
-client.query_contracted_reserve_prices(country_code, type_marketagreement_type, start=start, end=end, psr_type=None)
-client.query_contracted_reserve_amount(country_code, type_marketagreement_type, start=start, end=end, psr_type=None)
-client.query_unavailability_of_generation_units(country_code, start=start, end=end, docstatus=None, periodstartupdate=None, periodendupdate=None)
-client.query_unavailability_of_production_units(country_code, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
-client.query_unavailability_transmission(country_code_from, country_code_to, start=start, end=end, docstatus=None, periodstartupdate=None, periodendupdate=None)
-client.query_withdrawn_unavailability_of_generation_units(country_code, start, end)
+client.query_generation_per_plant(country_code, start=start, end=end,
+                                  psr_type=None, include_eic=False,
+                                  eic_code=None)
+client.query_installed_generation_capacity(country_code, start=start, end=end,
+                                           psr_type=None)
+client.query_installed_generation_capacity_per_unit(country_code, start=start,
+                                                    end=end, psr_type=None)
+client.query_imbalance_prices(country_code, start=start, end=end,
+                              psr_type=None)
+client.query_contracted_reserve_prices(country_code, type_marketagreement_type,
+                                       start=start, end=end, psr_type=None)
+client.query_contracted_reserve_amount(country_code, type_marketagreement_type,
+                                       start=start, end=end, psr_type=None)
+client.query_unavailability_of_generation_units(country_code, start=start,
+                                                end=end, docstatus=None,
+                                                periodstartupdate=None,
+                                                periodendupdate=None)
+client.query_unavailability_of_production_units(country_code, start, end,
+                                                docstatus=None,
+                                                periodstartupdate=None,
+                                                periodendupdate=None)
+client.query_unavailability_transmission(country_code_from, country_code_to,
+                                         start=start, end=end, docstatus=None,
+                                         periodstartupdate=None,
+                                         periodendupdate=None)
+client.query_withdrawn_unavailability_of_generation_units(country_code, start,
+                                                          end)
 client.query_unavailability_of_offshore_grid(area_code, start, end)
-client.query_physical_crossborder_allborders(country_code, start, end, export=True)
+client.query_physical_crossborder_allborders(country_code, start, end,
+                                             export=True)
 client.query_generation_import(country_code, start, end)
-client.query_procured_balancing_capacity(country_code, process_type, start=start, end=end, type_marketagreement_type=None)
+client.query_procured_balancing_capacity(country_code, process_type,
+                                         start=start, end=end,
+                                         type_marketagreement_type=None)
 
 ```
 #### Dump result to file

--- a/README.md
+++ b/README.md
@@ -11,20 +11,17 @@ The package comes with 2 clients:
 - [`EntsoeRawClient`](#EntsoeRawClient): Returns data in its raw format, usually XML or a ZIP-file containing XML's
 - [`EntsoePandasClient`](#EntsoePandasClient): Returns data parsed as a Pandas Series or DataFrame
 ### <a name="EntsoeRawClient"></a>EntsoeRawClient
-
 ```python
 from entsoe import EntsoeRawClient
 import pandas as pd
 
-client = EntsoeRawClient(api_key= < YOUR
-API
-KEY >)
+client = EntsoeRawClient(api_key=<YOUR API KEY>)
 
 start = pd.Timestamp('20171201', tz='Europe/Brussels')
 end = pd.Timestamp('20180101', tz='Europe/Brussels')
 country_code = 'BE'  # Belgium
 country_code_from = 'FR'  # France
-country_code_to = 'DE_LU'  # Germany-Luxembourg
+country_code_to = 'DE_LU' # Germany-Luxembourg
 type_marketagreement_type = 'A01'
 contract_marketagreement_type = 'A01'
 process_type = 'A51'
@@ -35,63 +32,33 @@ client.query_net_position(country_code, start, end, dayahead=True)
 client.query_load(country_code, start, end)
 client.query_load_forecast(country_code, start, end)
 client.query_wind_and_solar_forecast(country_code, start, end, psr_type=None)
-client.query_intraday_wind_and_solar_forecast(country_code, start, end,
-                                              psr_type=None)
+client.query_intraday_wind_and_solar_forecast(country_code, start, end, psr_type=None)
 client.query_generation_forecast(country_code, start, end)
 client.query_generation(country_code, start, end, psr_type=None)
-client.query_generation_per_plant(country_code, start, end, psr_type=None,
-                                  eic_code=None)
-client.query_installed_generation_capacity(country_code, start, end,
-                                           psr_type=None)
-client.query_installed_generation_capacity_per_unit(country_code, start, end,
-                                                    psr_type=None)
+client.query_generation_per_plant(country_code, start, end, psr_type=None)
+client.query_installed_generation_capacity(country_code, start, end, psr_type=None)
+client.query_installed_generation_capacity_per_unit(country_code, start, end, psr_type=None)
 client.query_crossborder_flows(country_code_from, country_code_to, start, end)
-client.query_scheduled_exchanges(country_code_from, country_code_to, start,
-                                 end, dayahead=False)
-client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to,
-                                            start, end)
-client.query_net_transfer_capacity_weekahead(country_code_from,
-                                             country_code_to, start, end)
-client.query_net_transfer_capacity_monthahead(country_code_from,
-                                              country_code_to, start, end)
-client.query_net_transfer_capacity_yearahead(country_code_from,
-                                             country_code_to, start, end)
-client.query_intraday_offered_capacity(country_code_from, country_code_to,
-                                       start, end, implicit=True)
-client.query_offered_capacity(country_code_from, country_code_to, start, end,
-                              contract_marketagreement_type, implicit=True)
-client.query_contracted_reserve_prices(country_code, start, end,
-                                       type_marketagreement_type,
-                                       psr_type=None)
-client.query_contracted_reserve_prices_procured_capacity(country_code, start,
-                                                         end, process_type
-type_marketagreement_type, psr_type = None)
-client.query_contracted_reserve_amount(country_code, start, end,
-                                       type_marketagreement_type,
-                                       psr_type=None)
-client.query_procured_balancing_capacity(country_code, start, end,
-                                         process_type,
-                                         type_marketagreement_type=None)
-client.query_aggregate_water_reservoirs_and_hydro_storage(country_code, start,
-                                                          end)
+client.query_scheduled_exchanges(country_code_from, country_code_to, start, end, dayahead=False)
+client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to, start, end)
+client.query_net_transfer_capacity_weekahead(country_code_from, country_code_to, start, end)
+client.query_net_transfer_capacity_monthahead(country_code_from, country_code_to, start, end)
+client.query_net_transfer_capacity_yearahead(country_code_from, country_code_to, start, end)
+client.query_intraday_offered_capacity(country_code_from, country_code_to, start, end, implicit=True)
+client.query_offered_capacity(country_code_from, country_code_to, start, end, contract_marketagreement_type, implicit=True)
+client.query_contracted_reserve_prices(country_code, start, end, type_marketagreement_type, psr_type=None)
+client.query_contracted_reserve_prices_procured_capacity(country_code, start, end, process_type type_marketagreement_type, psr_type=None)
+client.query_contracted_reserve_amount(country_code, start, end, type_marketagreement_type, psr_type=None)
+client.query_procured_balancing_capacity(country_code, start, end, process_type, type_marketagreement_type=None)
+client.query_aggregate_water_reservoirs_and_hydro_storage(country_code, start, end)
 
 # methods that return ZIP (bytes)
 client.query_imbalance_prices(country_code, start, end, psr_type=None)
-client.query_unavailability_of_generation_units(country_code, start, end,
-                                                docstatus=None,
-                                                periodstartupdate=None,
-                                                periodendupdate=None)
-client.query_unavailability_of_production_units(country_code, start, end,
-                                                docstatus=None,
-                                                periodstartupdate=None,
-                                                periodendupdate=None)
-client.query_unavailability_transmission(country_code_from, country_code_to,
-                                         start, end, docstatus=None,
-                                         periodstartupdate=None,
-                                         periodendupdate=None)
+client.query_unavailability_of_generation_units(country_code, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
+client.query_unavailability_of_production_units(country_code, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
+client.query_unavailability_transmission(country_code_from, country_code_to, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
 client.query_unavailability_of_offshore_grid(area_code, start, end)
-client.query_withdrawn_unavailability_of_generation_units(country_code, start,
-                                                          end)
+client.query_withdrawn_unavailability_of_generation_units(country_code, start, end)
 ```
 #### Dump result to file
 ```python
@@ -122,20 +89,17 @@ The Pandas Client works similar to the Raw Client, with extras:
 
 Please note that this client requires you to specifically set a start= and end= parameter which should be a pandas timestamp with timezone.
 If not it will throw an exception
-
 ```python
 from entsoe import EntsoePandasClient
 import pandas as pd
 
-client = EntsoePandasClient(api_key= < YOUR
-API
-KEY >)
+client = EntsoePandasClient(api_key=<YOUR API KEY>)
 
 start = pd.Timestamp('20171201', tz='Europe/Brussels')
 end = pd.Timestamp('20180101', tz='Europe/Brussels')
 country_code = 'BE'  # Belgium
 country_code_from = 'FR'  # France
-country_code_to = 'DE_LU'  # Germany-Luxembourg
+country_code_to = 'DE_LU' # Germany-Luxembourg
 type_marketagreement_type = 'A01'
 contract_marketagreement_type = "A01"
 process_type = 'A51'
@@ -143,73 +107,38 @@ process_type = 'A51'
 # methods that return Pandas Series
 client.query_day_ahead_prices(country_code, start=start, end=end)
 client.query_net_position(country_code, start=start, end=end, dayahead=True)
-client.query_crossborder_flows(country_code_from, country_code_to, start=start,
-                               end=end)
-client.query_scheduled_exchanges(country_code_from, country_code_to,
-                                 start=start, end=end, dayahead=False)
-client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to,
-                                            start=start, end=end)
-client.query_net_transfer_capacity_weekahead(country_code_from,
-                                             country_code_to, start=start,
-                                             end=end)
-client.query_net_transfer_capacity_monthahead(country_code_from,
-                                              country_code_to, start=start,
-                                              end=end)
-client.query_net_transfer_capacity_yearahead(country_code_from,
-                                             country_code_to, start=start,
-                                             end=end)
-client.query_intraday_offered_capacity(country_code_from, country_code_to,
-                                       start=start, end=end, implicit=True)
-client.query_offered_capacity(country_code_from, country_code_to,
-                              contract_marketagreement_type, start=start,
-                              end=end, implicit=True)
-client.query_aggregate_water_reservoirs_and_hydro_storage(country_code,
-                                                          start=start, end=end)
+client.query_crossborder_flows(country_code_from, country_code_to, start=start, end=end)
+client.query_scheduled_exchanges(country_code_from, country_code_to, start=start, end=end, dayahead=False)
+client.query_net_transfer_capacity_dayahead(country_code_from, country_code_to, start=start, end=end)
+client.query_net_transfer_capacity_weekahead(country_code_from, country_code_to, start=start, end=end)
+client.query_net_transfer_capacity_monthahead(country_code_from, country_code_to, start=start, end=end)
+client.query_net_transfer_capacity_yearahead(country_code_from, country_code_to, start=start, end=end)
+client.query_intraday_offered_capacity(country_code_from, country_code_to, start=start, end=end, implicit=True)
+client.query_offered_capacity(country_code_from, country_code_to, contract_marketagreement_type, start=start, end=end, implicit=True)
+client.query_aggregate_water_reservoirs_and_hydro_storage(country_code, start=start, end=end)
 
 # methods that return Pandas DataFrames
 client.query_load(country_code, start=start, end=end)
 client.query_load_forecast(country_code, start=start, end=end)
 client.query_load_and_forecast(country_code, start=start, end=end)
 client.query_generation_forecast(country_code, start=start, end=end)
-client.query_wind_and_solar_forecast(country_code, start=start, end=end,
-                                     psr_type=None)
-client.query_intraday_wind_and_solar_forecast(country_code, start=start,
-                                              end=end, psr_type=None)
+client.query_wind_and_solar_forecast(country_code, start=start, end=end, psr_type=None)
+client.query_intraday_wind_and_solar_forecast(country_code, start=start, end=end, psr_type=None)
 client.query_generation(country_code, start=start, end=end, psr_type=None)
-client.query_generation_per_plant(country_code, start=start, end=end,
-                                  psr_type=None, include_eic=False,
-                                  eic_code=None)
-client.query_installed_generation_capacity(country_code, start=start, end=end,
-                                           psr_type=None)
-client.query_installed_generation_capacity_per_unit(country_code, start=start,
-                                                    end=end, psr_type=None)
-client.query_imbalance_prices(country_code, start=start, end=end,
-                              psr_type=None)
-client.query_contracted_reserve_prices(country_code, type_marketagreement_type,
-                                       start=start, end=end, psr_type=None)
-client.query_contracted_reserve_amount(country_code, type_marketagreement_type,
-                                       start=start, end=end, psr_type=None)
-client.query_unavailability_of_generation_units(country_code, start=start,
-                                                end=end, docstatus=None,
-                                                periodstartupdate=None,
-                                                periodendupdate=None)
-client.query_unavailability_of_production_units(country_code, start, end,
-                                                docstatus=None,
-                                                periodstartupdate=None,
-                                                periodendupdate=None)
-client.query_unavailability_transmission(country_code_from, country_code_to,
-                                         start=start, end=end, docstatus=None,
-                                         periodstartupdate=None,
-                                         periodendupdate=None)
-client.query_withdrawn_unavailability_of_generation_units(country_code, start,
-                                                          end)
+client.query_generation_per_plant(country_code, start=start, end=end, psr_type=None, include_eic=False)
+client.query_installed_generation_capacity(country_code, start=start, end=end, psr_type=None)
+client.query_installed_generation_capacity_per_unit(country_code, start=start, end=end, psr_type=None)
+client.query_imbalance_prices(country_code, start=start, end=end, psr_type=None)
+client.query_contracted_reserve_prices(country_code, type_marketagreement_type, start=start, end=end, psr_type=None)
+client.query_contracted_reserve_amount(country_code, type_marketagreement_type, start=start, end=end, psr_type=None)
+client.query_unavailability_of_generation_units(country_code, start=start, end=end, docstatus=None, periodstartupdate=None, periodendupdate=None)
+client.query_unavailability_of_production_units(country_code, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
+client.query_unavailability_transmission(country_code_from, country_code_to, start=start, end=end, docstatus=None, periodstartupdate=None, periodendupdate=None)
+client.query_withdrawn_unavailability_of_generation_units(country_code, start, end)
 client.query_unavailability_of_offshore_grid(area_code, start, end)
-client.query_physical_crossborder_allborders(country_code, start, end,
-                                             export=True)
+client.query_physical_crossborder_allborders(country_code, start, end, export=True)
 client.query_generation_import(country_code, start, end)
-client.query_procured_balancing_capacity(country_code, process_type,
-                                         start=start, end=end,
-                                         type_marketagreement_type=None)
+client.query_procured_balancing_capacity(country_code, process_type, start=start, end=end, type_marketagreement_type=None)
 
 ```
 #### Dump result to file

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -374,7 +374,8 @@ class EntsoeRawClient:
 
     def query_generation_per_plant(
             self, country_code: Union[Area, str], start: pd.Timestamp,
-            end: pd.Timestamp, psr_type: Optional[str] = None, **kwargs) -> str:
+            end: pd.Timestamp, psr_type: Optional[str] = None,
+            eic_code: Optional[str] = None, **kwargs) -> str:
         """
         Parameters
         ----------
@@ -383,6 +384,8 @@ class EntsoeRawClient:
         end : pd.Timestamp
         psr_type : str
             filter on a single psr type
+        eic_code : str
+            filter on a single Generation Unit using its EIC Code
 
         Returns
         -------
@@ -396,6 +399,8 @@ class EntsoeRawClient:
         }
         if psr_type:
             params.update({'psrType': psr_type})
+        if eic_code:
+            params.update({'registeredResource': eic_code})
         response = self._base_request(params=params, start=start, end=end)
         return response.text
 
@@ -2210,7 +2215,8 @@ class EntsoePandasClient(EntsoeRawClient):
             self, country_code: Union[Area, str], start: pd.Timestamp,
             end: pd.Timestamp, psr_type: Optional[str] = None,
             include_eic: bool = False,
-             **kwargs) -> pd.DataFrame:
+            eic_code: Optional[str] = None,
+            **kwargs) -> pd.DataFrame:
         """
         Parameters
         ----------
@@ -2221,6 +2227,8 @@ class EntsoePandasClient(EntsoeRawClient):
             filter on a single psr type
         include_eic: bool
             if True also include the eic code in the output
+        eic_code : str
+            filter on a single Generation Unit using its EIC Code
 
         Returns
         -------
@@ -2228,7 +2236,9 @@ class EntsoePandasClient(EntsoeRawClient):
         """
         area = lookup_area(country_code)
         text = super(EntsoePandasClient, self).query_generation_per_plant(
-            country_code=area, start=start, end=end, psr_type=psr_type)
+            country_code=area, start=start, end=end, psr_type=psr_type,
+            eic_code=eic_code,
+        )
         df = parse_generation(text, per_plant=True, include_eic=include_eic)
         df.columns = df.columns.set_levels(df.columns.levels[0].str.encode('latin-1').str.decode('utf-8'), level=0)
         df = df.tz_convert(area.tz)


### PR DESCRIPTION
This PR adds a parameter `eic_code` to `query_generation_per_plant` to filter on a single generation unit. The parameter is simply passed to the API's parameter `RegisteredResource` (see documentation [here](https://documenter.getpostman.com/view/7009892/2s93JtP3F6#537e921c-b261-46d1-9515-32958e8f520a)).