### PR TITLE
Add query production and generation units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ settings.py
 
 # user settings, for example to store api key
 secret.py
+.vscode/settings.json

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -453,6 +453,33 @@ class EntsoeRawClient:
         response = self._base_request(params=params, start=start, end=end)
         return response.text
 
+    def query_production_and_generation_units(
+            self, country_code: Union[Area, str], start: pd.Timestamp,
+            end: pd.Timestamp, psr_type: Optional[str] = None) -> str:
+        """
+        Parameters
+        ----------
+        country_code : Area|str
+        start : pd.Timestamp
+        end : pd.Timestamp
+        psr_type : str
+            filter query for a specific psr type
+
+        Returns
+        -------
+        str
+        """
+        area = lookup_area(country_code)
+        params = {
+            'documentType': 'A95',
+            'businessType': 'B11',
+            'BiddingZone_Domain': area.code,
+        }
+        if psr_type:
+            params.update({'psrType': psr_type})
+        response = self._base_request(params=params, start=start, end=end)
+        return response.text
+
     def query_aggregate_water_reservoirs_and_hydro_storage(self, country_code: Union[Area, str], start: pd.Timestamp,
             end: pd.Timestamp) -> str:
         """

--- a/tests.py
+++ b/tests.py
@@ -30,6 +30,7 @@ class EntsoeRawClientTest(unittest.TestCase):
             self.client.query_generation,
             self.client.query_generation_forecast,
             self.client.query_installed_generation_capacity,
+            self.client.query_production_and_generation_units,
             # these give back a zip so disabled for testing right now
             #self.client.query_imbalance_prices,
             #self.client.query_imbalance_volumes,

--- a/tests.py
+++ b/tests.py
@@ -12,8 +12,8 @@ class EntsoeRawClientTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.client = EntsoeRawClient(api_key=api_key)
-        cls.start = pd.Timestamp('20180101', tz='Europe/Brussels')
-        cls.end = pd.Timestamp('20180107', tz='Europe/Brussels')
+        cls.start = pd.Timestamp('20230101', tz='Europe/Brussels')
+        cls.end = pd.Timestamp('20240101', tz='Europe/Brussels')
         cls.country_code = 'BE'
 
     def test_datetime_to_str(self):
@@ -74,6 +74,20 @@ class EntsoeRawClientTest(unittest.TestCase):
             process_type='A51'
         )
         self.assertIsInstance(text, bytes)
+        try:
+            BeautifulSoup(text, 'html.parser')
+        except Exception as e:
+            self.fail(f'Parsing of response failed with exception: {e}')
+
+    def test_query_production_and_generation_units(self):
+
+        # start=pd.Timestamp('20210101', tz='Europe/Brussels'),
+        # end=pd.Timestamp('20210102', tz='Europe/Brussels'),
+        Implementation_DateAndOrTime = pd.Timestamp('20210101', tz='Europe/Brussels')
+
+        text = self.client.query_production_and_generation_units(
+            country_code='BE', Implementation_DateAndOrTime=Implementation_DateAndOrTime)
+        self.assertIsInstance(text, str)
         try:
             BeautifulSoup(text, 'html.parser')
         except Exception as e:
@@ -210,6 +224,12 @@ class EntsoePandasClientTest(EntsoeRawClientTest):
                 type_marketagreement_type='A01',
                 start=pd.Timestamp('20240101', tz='Europe/Oslo'),
                 end=pd.Timestamp('20240118', tz='Europe/Oslo'))
+            
+    def test_query_production_and_generation_units(self):
+        Implementation_DateAndOrTime = pd.Timestamp('20210101', tz='Europe/Brussels')
+        ts = self.client.query_production_and_generation_units(
+            country_code='BE', Implementation_DateAndOrTime=Implementation_DateAndOrTime)
+        self.assertIsInstance(ts, pd.DataFrame)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request introduces new functionalities to the `entsoe-py` library, specifically focusing on parsing and querying production and generation units #385 . The following changes have been implemented:

1. **New Methods:**
   - Added `parse_production_and_generation_units` method to parse data related to production and generation units.
   - Added `query_production_and_generation_units` method to retrieve information on production and generation units.

2. **Base Request Adaptation:**
   - Adapted the `_base_request` method to receive the parameter `Implementation_DateAndOrTime` and handle it accordingly. Other functionalities remain unchanged.

**Note:**
The `parse_production_and_generation_units` method is not yet able to extract all data. I am seeking support to enhance this functionality and ensure comprehensive data extraction. For more details on the data structure, please refer to the [[ProductionAndGenerationUnits_r2 documentation](https://transparencyplatform.zendesk.com/hc/en-us/articles/25430753481489-ProductionAndGenerationUnits-r2)]