### PR TITLE
Make ENTSO-E API endopint URL customizable for testing or debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,8 @@ For bidding zone that have changed (splitted/merged) some codes are only valid f
 | DE | No Value | No Value | No Value | No Value | No Value | No Value | No Value |
 | DE_LU | No Value | No Value | No Value | yes | yes | yes | yes |
 | AT | No Value | No Value | No Value | yes | yes | yes | yes |
+
+### Environment variables
+| Variables | Description |
+| -- | -- |
+| ENTSOE_ENDPOINT_URL | Override the default ENTSO-E API endpoint URL. |

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Union, Optional, Dict, List, Literal
 
 import pandas as pd
@@ -28,7 +29,7 @@ __version__ = "0.6.18"
 __author__ = "EnergieID.be, Frank Boerman"
 __license__ = "MIT"
 
-URL = 'https://web-api.tp.entsoe.eu/api'
+URL = os.getenv("ENTSOE_ENDPOINT_URL") or "https://web-api.tp.entsoe.eu/api"
 
 
 class EntsoeRawClient:


### PR DESCRIPTION
It would be better if application developers can change the default ENTSO-E API endpoint URL for testing or debugging.

This PR allows app developers or testers to change the endpoint URL by environment variable `ENTSOE_ENDPOINT_URL`. They can easily perform integration tests of various API error cases in a deterministic way using their local web server.

This variable works like [AWS_ENDPOINT_URL](https://aws.amazon.com/blogs/developer/new-improved-flexibility-when-configuring-endpoint-urls-with-the-aws-sdks-and-tools/) variable for AWS SDK.