### PR TITLE
Missing neigbours in mappings.py

### DIFF
--- a/entsoe/mappings.py
+++ b/entsoe/mappings.py
@@ -363,4 +363,11 @@ NEIGHBOURS = {
     'IT_CALA': ['IT_SICI', 'IT_SUD'],
     'MT': ['IT_SICI'],
     'HR': ['BA', 'HU', 'RS', 'SI']
+    'AL': ['GR', 'XR', 'ME', 'RS'],
+    'DK': ['DE', 'NL', 'NO', 'SE', 'GB'],
+    'MD': ['RO', 'UA_IPS'],
+    'NO': ['DK', 'FI', 'DE', 'NL', 'SE', 'GB'],
+    'SE': ['DK', 'FI', 'DE', 'LT', 'NO', 'PL'],
+    'UA_IPS': ['BY', 'HU', 'MD', 'PL', 'RO', 'RU', 'SK'],
+    'XK': ['AL', 'ME', 'MK']
 }


### PR DESCRIPTION
Added missing neighbours in mappings.py added. 
Country codes should match ENTSO-E cross-border data.

