### PR TITLE
specify encoding to avoid UnicodeDecodeError

### DIFF
--- a/entsoe/files/entsoe_files.py
+++ b/entsoe/files/entsoe_files.py
@@ -102,7 +102,7 @@ class EntsoeFileClient:
         stream.seek(0)
         zf = zipfile.ZipFile(stream)
         with zf.open(zf.filelist[0].filename) as file:
-            return pd.read_csv(file, sep='\t')
+            return pd.read_csv(file, sep='\t', encoding='unicode_escape')
 
     @check_expired
     def download_multiple_files(self, file_ids: list) -> pd.DataFrame:
@@ -127,7 +127,7 @@ class EntsoeFileClient:
         df = []
         for fz in zf.filelist:
             with zf.open(fz.filename) as file:
-                df.append(pd.read_csv(file, sep='\t'))
+                df.append(pd.read_csv(file, sep='\t', encoding='unicode_escape'))
 
         return pd.concat(df)
 


### PR DESCRIPTION
default utf-8 fails on special characters (PU/GU names)