### PR TITLE
Optional support for resolution in imbalance price and imbalance volume

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1830,7 +1830,7 @@ class EntsoePandasClient(EntsoeRawClient):
     @year_limited
     def query_imbalance_prices(
             self, country_code: Union[Area, str], start: pd.Timestamp,
-            end: pd.Timestamp, psr_type: Optional[str] = None) -> pd.DataFrame:
+            end: pd.Timestamp, psr_type: Optional[str] = None, include_resolution = False) -> pd.DataFrame:
         """
         Parameters
         ----------
@@ -1839,7 +1839,8 @@ class EntsoePandasClient(EntsoeRawClient):
         end : pd.Timestamp
         psr_type : str
             filter query for a specific psr type
-
+        include_resolution: bool
+            Add resolution columns to the result
         Returns
         -------
         pd.DataFrame
@@ -1847,7 +1848,7 @@ class EntsoePandasClient(EntsoeRawClient):
         area = lookup_area(country_code)
         archive = super(EntsoePandasClient, self).query_imbalance_prices(
             country_code=area, start=start, end=end, psr_type=psr_type)
-        df = parse_imbalance_prices_zip(zip_contents=archive)
+        df = parse_imbalance_prices_zip(zip_contents=archive, include_resolution=include_resolution)
         df = df.tz_convert(area.tz)
         df = df.truncate(before=start, after=end)
         return df
@@ -1855,7 +1856,7 @@ class EntsoePandasClient(EntsoeRawClient):
     @year_limited
     def query_imbalance_volumes(
             self, country_code: Union[Area, str], start: pd.Timestamp,
-            end: pd.Timestamp, psr_type: Optional[str] = None) -> pd.DataFrame:
+            end: pd.Timestamp, psr_type: Optional[str] = None, include_resolution=False) -> pd.DataFrame:
         """
         Parameters
         ----------
@@ -1864,7 +1865,8 @@ class EntsoePandasClient(EntsoeRawClient):
         end : pd.Timestamp
         psr_type : str
             filter query for a specific psr type
-
+        include_resolution: bool
+            include resolution column in the result
         Returns
         -------
         pd.DataFrame
@@ -1872,7 +1874,7 @@ class EntsoePandasClient(EntsoeRawClient):
         area = lookup_area(country_code)
         archive = super(EntsoePandasClient, self).query_imbalance_volumes(
             country_code=area, start=start, end=end, psr_type=psr_type)
-        df = parse_imbalance_volumes_zip(zip_contents=archive)
+        df = parse_imbalance_volumes_zip(zip_contents=archive, include_resolution=include_resolution)
         df = df.tz_convert(area.tz)
         df = df.truncate(before=start, after=end)
         return df

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1830,7 +1830,7 @@ class EntsoePandasClient(EntsoeRawClient):
     @year_limited
     def query_imbalance_prices(
             self, country_code: Union[Area, str], start: pd.Timestamp,
-            end: pd.Timestamp, psr_type: Optional[str] = None, include_resolution = False) -> pd.DataFrame:
+            end: pd.Timestamp, psr_type: Optional[str] = None, include_resolution: bool = False) -> pd.DataFrame:
         """
         Parameters
         ----------

--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1851,6 +1851,10 @@ class EntsoePandasClient(EntsoeRawClient):
         df = parse_imbalance_prices_zip(zip_contents=archive, include_resolution=include_resolution)
         df = df.tz_convert(area.tz)
         df = df.truncate(before=start, after=end)
+        # 
+        if include_resolution:
+            df = df.rename(columns={'Resolution Long': 'Resolution'})
+            df.drop(columns=['Resolution Short'], inplace=True)
         return df
 
     @year_limited

--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -496,7 +496,7 @@ def _parse_contracted_reserve_series(soup, tz, label):
     df.columns = pd.MultiIndex.from_product([df.columns, [direction]])
     return df
 
-def parse_imbalance_prices_zip(zip_contents: bytes, include_resolution=False) -> pd.DataFrame:
+def parse_imbalance_prices_zip(zip_contents: bytes, include_resolution: bool =False) -> pd.DataFrame:
     """
     Parameters
     ----------
@@ -607,7 +607,7 @@ def _parse_imbalance_prices_timeseries(soup, include_resolution=False) -> pd.Dat
             df['resolution_short'] = None
     return df
 
-def parse_imbalance_volumes_zip(zip_contents: bytes, include_resolution: False) -> pd.DataFrame:
+def parse_imbalance_volumes_zip(zip_contents: bytes, include_resolution:bool = False) -> pd.DataFrame:
     """
     Parameters
     ----------

--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -598,13 +598,13 @@ def _parse_imbalance_prices_timeseries(soup, include_resolution=False) -> pd.Dat
         if period is not None and period.find('resolution') is not None:
             resolution = period.find('resolution').text
         if 'Long' in df.columns:
-            df['resolution_long'] = resolution
+            df['Resolution Long'] = resolution
         else:
-            df['resolution_long'] = None
+            df['Resolution Long'] = None
         if 'Short' in df.columns:
-            df['resolution_short'] = resolution
+            df['Resolution Short'] = resolution
         else:
-            df['resolution_short'] = None
+            df['Resolution Short'] = None
     return df
 
 def parse_imbalance_volumes_zip(zip_contents: bytes, include_resolution:bool = False) -> pd.DataFrame:
@@ -664,7 +664,7 @@ def _parse_imbalance_volumes_timeseries(soup, include_resolution) -> pd.DataFram
             df.loc[dt, 'Imbalance Volume'] = \
                 float(point.find('quantity').text) * flow_direction_factor
         if include_resolution:
-            df["resolution"] = resolution
+            df["Resolution"] = resolution
     df.set_index(['Imbalance Volume'])
 
     return df


### PR DESCRIPTION
Added support to optionally include time resolution from ENTSOE XML responses when parsing to DataFrame. This is controlled via a new include_resolution flag, defaulting to False for backward compatibility.