### PR TITLE
Mark as supporting type hints via py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,4 +71,5 @@ setup(
     install_requires=['requests', 'pytz', 'beautifulsoup4>=4.11.1', 'pandas>=2.2.0'],
 
     include_package_data=True,
+    package_data={"entsoe": ["py.typed"]}
 )


### PR DESCRIPTION
Another quick driveby - currently, consuming projects running mypy etc will treat `entsoe-py` as untyped because this is Python's default.
To opt in to exposing its types to consumers, packages need to include a file `py.typed`. As per this PR. :)

N.B. the types do look sort of incomplete, so by exposing this you might be opening the door to more drivebys from people wanting to tighten them up. Unsure if that's a positive or a negative :)