### PR TITLE
fix2025: interpolation issues imbalance volumes for current balancing…

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -660,8 +660,9 @@ def _parse_imbalance_volumes_timeseries(soup, include_resolution) -> pd.DataFram
         tx = pd.date_range(start=start, end=end, freq=resolution, inclusive='left')
         points = period.find_all('point')
 
-        for dt, point in zip(tx, points):
-            df.loc[dt, 'Imbalance Volume'] = \
+        for point in points:
+            position = int(point.find('position').text)
+            df.loc[tx[position-1], 'Imbalance Volume'] = \
                 float(point.find('quantity').text) * flow_direction_factor
         if include_resolution:
             df["Resolution"] = resolution


### PR DESCRIPTION
The function _parse_imbalance_volumes_timeseries parsing the xml files from current balancing state isn't taking in consideration the 'position' value for the data that is parsing.
Fix index assignment in _parse_imbalance_volumes_timeseries to correctly map imbalance volume values to their corresponding timestamps. Previously, the code used zip(tx, points), which could misalign time indices if positions were not sequential. Now, it uses the position field from each point to ensure accurate placement in the DataFrame.

Code to test it:

def _main():
    from entsoe import EntsoeRawClient
    from datetime import datetime, timedelta
    import pandas as pd
    from entsoe.parsers import parse_imbalance_volumes

    area_code = '10YFR-RTE------C'
    params = {
        'documentType': 'A86',
        'businessType': 'B33',
        'area_Domain': area_code
    }
    start = datetime(2025, 1, 1, 0, 0, 0, tzinfo=pd.Timestamp.utcnow().tz)

    query_start = pd.Timestamp(start)
    query_end = pd.Timestamp(start + timedelta(days=1))

    raw_client = EntsoeRawClient(api_key=ENTSOE_API_KEY)
    response = raw_client._base_request(params=params, start=query_start, end=query_end)
    parsed_cbs_df = parse_imbalance_volumes(response.content)
    parsed_cbs_df = parsed_cbs_df["Imbalance Volume"].rename(None).tz_convert("UTC")

    print(parsed_cbs_df.head(5))

Prefix output for france data the first of January:
2025-01-01 00:00:00+00:00      3.62
2025-01-01 00:15:00+00:00    -42.06
2025-01-01 00:16:00+00:00   -129.66
2025-01-01 00:45:00+00:00      70.6
2025-01-01 01:00:00+00:00   -353.74

Expected output (after update):
2025-01-01 00:00:00+00:00      3.62
2025-01-01 00:15:00+00:00    -42.06
2025-01-01 00:30:00+00:00   -129.66
2025-01-01 00:45:00+00:00      70.6
2025-01-01 01:00:00+00:00   -353.74

The result remains the same for actual one minute resolution data.
