### PR TITLE
Exclude tests directory from package installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests', 'tests.*']),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:


### PR DESCRIPTION
Fix setup.py to exclude tests directory using find_packages(exclude=['tests'])

When the tests directory is installed with with the package in the global namespace it pollutes the namespace and can cause issues with test discovery tools like pytest.
E.g. a project using its own `tests` directory with pylint using this package will get the error:
```
************* Module tests
tests/init.py:1:0: F0010: error while code parsing: Unable to load file tests/init.py:
[Errno 2] No such file or directory: 'tests/init.py' (parse-error)


This forced us for example, to stick with version 0.7.0 of the package which did not have this issue.
