### PR TITLE
fix: handle zip response for query contracted reserve prices procured capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ client.query_net_transfer_capacity_yearahead(country_code_from, country_code_to,
 client.query_intraday_offered_capacity(country_code_from, country_code_to, start, end, implicit=True)
 client.query_offered_capacity(country_code_from, country_code_to, start, end, contract_marketagreement_type, implicit=True)
 client.query_contracted_reserve_prices(country_code, start, end, type_marketagreement_type, psr_type=None)
-client.query_contracted_reserve_prices_procured_capacity(country_code, start, end, process_type type_marketagreement_type, psr_type=None)
 client.query_contracted_reserve_amount(country_code, start, end, type_marketagreement_type, psr_type=None)
 client.query_procured_balancing_capacity(country_code, start, end, process_type, type_marketagreement_type=None)
 client.query_aggregate_water_reservoirs_and_hydro_storage(country_code, start, end)
@@ -63,6 +62,7 @@ client.query_unavailability_of_production_units(country_code, start, end, docsta
 client.query_unavailability_transmission(country_code_from, country_code_to, start, end, docstatus=None, periodstartupdate=None, periodendupdate=None)
 client.query_unavailability_of_offshore_grid(area_code, start, end)
 client.query_withdrawn_unavailability_of_generation_units(country_code, start, end)
+client.query_contracted_reserve_prices_procured_capacity(country_code, start, end, process_type type_marketagreement_type, psr_type=None)
 ```
 #### Dump result to file
 ```python


### PR DESCRIPTION
I thought I'd attempt to fix #450 by looking at how querying similar endpoints with zip file response is done in the codebase, but I'm having problems getting it working as intended.

Posting a draft PR here to get some help/feedback, or perhaps someone who knows the codebase better can take over from here.

---

I'm using the following code snippet for (manual) testing:

```python
import pandas as pd
from entsoe import EntsoeRawClient
from entsoe.entsoe import EntsoePandasClient
from entsoe.mappings import Area
from entsoe.parsers import parse_contracted_reserve_zip

raw_client = EntsoeRawClient(api_key="<redacted>")

xml_text = raw_client.query_contracted_reserve_prices_procured_capacity(
    country_code=Area.NO_2,
    process_type="A51",
    type_marketagreement_type="A01",
    start=pd.Timestamp("2025-10-11T00:00:00", tz="Europe/Oslo"),
    end=pd.Timestamp("2025-10-12T00:00:00", tz="Europe/Oslo"),
)

content = raw_client.query_contracted_reserve_prices_procured_capacity(
    Area.NO_2,
    start=pd.Timestamp("2025-10-11T00:00:00", tz="Europe/Oslo"),
    end=pd.Timestamp("2025-10-12T00:00:00", tz="Europe/Oslo"),
    process_type="A51",
    type_marketagreement_type="A01",
)

volumes_df = parse_contracted_reserve_zip(content, "Europe/Oslo", "quantity")
prices_df = parse_contracted_reserve_zip(content, "Europe/Oslo", "procurement_price.amount")

pd_client = EntsoePandasClient(api_key="<redacted>")
prices_df_2 = pd_client.query_contracted_reserve_prices_procured_capacity(
    Area.NO_2,
    start=pd.Timestamp("2025-10-11T00:00:00", tz="Europe/Oslo"),
    end=pd.Timestamp("2025-10-12T00:00:00", tz="Europe/Oslo"),
    process_type="A51",
    type_marketagreement_type="A01",
)

breakpoint()  # Manually verify a few values compared to data shown on Entsoe Transparency Platform UI
```

With my PR applied entsoe-py no longer crashes on the above snippets, and I'm able to get a dataframe back.
But only the first few values are correct when cross-checking against Entsoe transparency platform UI.

I think the next step is to dig deeper into the xml response and parsers._parse_contracted_reserve_series function,
but I'm likely out of time for the next couple of days, so again feel free to take over from here (or just start from stratch if its easier :sweat_smile:)