### PR TITLE
Fix : handle no matching data xml with text/xml content type

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -138,7 +138,7 @@ class EntsoeRawClient:
             # this means we need to check the contents for this error even when status code 200 is returned
             # to prevent parsing the full response do a text matching instead of full parsing
             # also only do this when response type content is text and not for example a zip file
-            if response.headers.get('content-type', '') == 'application/xml':
+            if response.headers.get('content-type', '') in ['application/xml', 'text/xml']:
                 if 'No matching data found' in response.text:
                     raise NoMatchingDataError
             return response


### PR DESCRIPTION
<img width="1355" height="937" alt="image" src="https://github.com/user-attachments/assets/399e133c-9dbf-4813-87be-f45e78a436fa" />

The API seems to be responding with status 200 "No matching data" Xml with content-type "text/xml" instead of "application/xml", which causes the if line 142 to not be checked.