### PR TITLE
Exclude tests from package in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include LICENSE
 include requirements.txt
 include entsoe/geo/geojson/*.geojson
 include entsoe/*
+exclude tests/*


### PR DESCRIPTION
Hi, we got a problem on one of our repostories where our `tests` folder was shadowed by the `tests` package from entsoe-py after the update from 0.6 to 0.7. Here is a modification to remove the tests folder from the release archive. 
In the meanwhile we fixed it by adding a __init__.py in our tests folder but it can be useful for others. Thanks