### PR TITLE
handle comma in `TimeSeries/…/point/position`

### DIFF
--- a/entsoe/series_parsers.py
+++ b/entsoe/series_parsers.py
@@ -97,10 +97,12 @@ def _parse_timeseries_generic(soup, label='quantity', to_float=True, merge_serie
         delta_text = _resolution_to_timedelta(res_text=period.find('resolution').text)
         delta = pd.Timedelta(delta_text)
         for point in period.find_all('point'):
+            position = point.find('position').text
             value = point.find(label).text
             if to_float:
+                position = position.replace(',', '')
                 value = value.replace(',', '')
-            position = int(point.find('position').text)
+            position = int(position)
             data[start + (position-1)*delta] = value
         S = pd.Series(data).sort_index()
         if soup.find('curvetype').text == 'A03':


### PR DESCRIPTION
Querying imbalance volumes [1], can lead to a stack trace [2] because the response [3] contains a comma that gets converted to `int()`.

The corresponding preexisting code in `series_parsers.py` suggest that those commas are to be ignored for `quantity`. This PR thus adds removal of commas in `position` as well.

As always, thanks for `entsoe-py`, thanks for considering, and kind regards.

<details>
<summary>[1] query</summary>

`GET /api?documentType=A86&controlArea_Domain=10YDE-EON------1&periodStart=202507152200&periodEnd=202510232200&securityToken=…`

</details>

<details>
<summary>[2] stack trace</summary>

```
  File "…/venv/lib/python3.13/site-packages/entsoe/decorators.py", line 129, in year_wrapper
    frame = func(*args, start=_start, end=_end, **kwargs)
  File "…/venv/lib/python3.13/site-packages/entsoe/entsoe.py", line 2020, in query_imbalance_volumes
    df = parse_imbalance_volumes_zip(zip_contents=archive, include_resolution=include_resolution)
  File "…/venv/lib/python3.13/site-packages/entsoe/parsers.py", line 667, in parse_imbalance_volumes_zip
    df = pd.concat(frames)
  File "…/venv/lib/python3.13/site-packages/pandas/core/reshape/concat.py", line 382, in concat
    op = _Concatenator(
        objs,
    ...<8 lines>...
        sort=sort,
    )
  File "…/venv/lib/python3.13/site-packages/pandas/core/reshape/concat.py", line 445, in __init__
    objs, keys = self._clean_keys_and_objs(objs, keys)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "…/venv/lib/python3.13/site-packages/pandas/core/reshape/concat.py", line 504, in _clean_keys_and_objs
    objs_list = list(objs)
  File "…/venv/lib/python3.13/site-packages/entsoe/parsers.py", line 663, in gen_frames
    frame = parse_imbalance_volumes(xml_text=arc.read(f), include_resolution=include_resolution)
  File "…/venv/lib/python3.13/site-packages/entsoe/parsers.py", line 309, in parse_imbalance_volumes
    df = pd.concat(frames, axis=1)
  File "…/venv/lib/python3.13/site-packages/pandas/core/reshape/concat.py", line 382, in concat
    op = _Concatenator(
        objs,
    ...<8 lines>...
        sort=sort,
    )
  File "…/venv/lib/python3.13/site-packages/pandas/core/reshape/concat.py", line 445, in __init__
    objs, keys = self._clean_keys_and_objs(objs, keys)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "…/venv/lib/python3.13/site-packages/pandas/core/reshape/concat.py", line 504, in _clean_keys_and_objs
    objs_list = list(objs)
  File "…/venv/lib/python3.13/site-packages/entsoe/parsers.py", line 307, in <genexpr>
    frames = (_parse_imbalance_volumes_timeseries(soup, include_resolution)
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "…/venv/lib/python3.13/site-packages/entsoe/parsers.py", line 695, in _parse_imbalance_volumes_timeseries
    'Imbalance Volume': _parse_timeseries_generic(soup, label='quantity', merge_series=True) * flow_direction_factor
                        ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "…/venv/lib/python3.13/site-packages/entsoe/series_parsers.py", line 103, in _parse_timeseries_generic
    position = int(point.find('position').text)
ValueError: invalid literal for int() with base 10: '1,154'
make: *** [Makefile:40: run-test] Error 1
```

</details>

<details>
<summary>[3] response</summary>

```
<?xml version="1.0" encoding="UTF-8"?>
  <Balancing_MarketDocument xmlns="…">
    <mRID>…</mRID>
    <revisionNumber>1</revisionNumber>
    <type>A86</type>
    <process.processType>A16</process.processType>
    …
    <period.timeInterval>
      <start>2025-10-01T00:00Z</start>
      <end>2025-10-23T22:00Z</end>
    </period.timeInterval>
      <TimeSeries>
        <mRID>2</mRID>
        <businessType>A19</businessType>
        <flowDirection.direction>A01</flowDirection.direction>
        <quantity_Measure_Unit.name>MWH</quantity_Measure_Unit.name>
        <curveType>A03</curveType>
…
          <Period>
            <timeInterval>
              <start>2025-10-05T21:45Z</start>
              <end>2025-10-17T22:15Z</end>
            </timeInterval>
            <resolution>PT15M</resolution>
…
              <Point>
                <position>1,154</position>
                <quantity>4.440025</quantity>
                <secondaryQuantity>-2.310772</secondaryQuantity>
              </Point>
 …
```

</details>