### PR TITLE
fix bids to allow for more parameters

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -238,8 +238,8 @@ class EntsoeRawClient:
         -------
         str
         """
-        if process_type not in ['A51', 'A52', 'A47']:
-            raise ValueError('processType allowed values: A51, A52, A47')
+        if process_type not in ['A51', 'A46', 'A47', 'A60', 'A61', 'A67', 'A68']:
+            raise ValueError('processType allowed values: A51, A46, A47, A60, A61, A67, A68')
         area = lookup_area(country_code)
         params = {
             'documentType': 'A24',


### PR DESCRIPTION
fixes #398, to enable to choose afrr local or central selection. I looked on Postman TRANSPARENCY PLATFORM RESTFUL API 12.3.E Aggregated Balancing Energy Bids (GL EB) to know what are the available parameters. 