### PR TITLE
Ignore empty time series when parsing

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -136,7 +136,9 @@ def parse_generation(
     all_series = dict()
     for soup in _extract_timeseries(xml_text):
         ts = _parse_generation_timeseries(soup, per_plant=per_plant, include_eic=include_eic)
-
+        if ts is None or ts.empty:
+            continue
+        
         # check if we already have a series of this name
         series = all_series.get(ts.name)
         if series is None:

--- a/entsoe/series_parsers.py
+++ b/entsoe/series_parsers.py
@@ -120,6 +120,16 @@ def _parse_timeseries_generic(soup, label='quantity', to_float=True, merge_serie
         else:
             series[freq] = None
 
+    # Filter out empty entries
+    series = {
+        k: v for k, v in series.items()
+        if v is not None and not v.empty
+    }
+
+    # Do not concatenate if no data
+    if not series:
+        return pd.Series(dtype=float)
+
     # for endpoints which never has duplicated timeseries the flag merge_series signals to just concat everything
     if merge_series:
         return pd.concat(series.values())


### PR DESCRIPTION
Fixes #485 : Appearance of empty time series in the XML returned by entsoe caused the parsers to crash when attempting to concatenate empty series 

Changes: _parse_timeseries_generic() and parse_generation() skip empty timeseries