### PR TITLE
fix to issue-504

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -32,7 +32,9 @@ __license__ = "MIT"
 
 URL = os.getenv("ENTSOE_ENDPOINT_URL") or "https://web-api.tp.entsoe.eu/api"
 
-QUARTER_MTU_SDAC_GOLIVE =  pd.Timestamp('2025-10-01', tz='europe/amsterdam')
+
+QUARTER_MTU_SDAC_GOLIVE = pd.Timestamp('2025-10-01', tz='Europe/Amsterdam')
+
 
 
 class EntsoeRawClient:

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -1,0 +1,10 @@
+import pandas as pd
+from zoneinfo import ZoneInfo
+
+def test_zoneinfo_key_europe_amsterdam_is_valid():
+    ZoneInfo("Europe/Amsterdam")
+
+def test_entsoe_import_does_not_fail_due_to_timezone():
+    import entsoe.entsoe as e
+    assert isinstance(e.QUARTER_MTU_SDAC_GOLIVE, pd.Timestamp)
+    assert e.QUARTER_MTU_SDAC_GOLIVE.tz is not None


### PR DESCRIPTION
**What**

This PR fixes an invalid IANA timezone key used at import time:

pd.Timestamp("2025-10-01", tz="europe/amsterdam")

The key has been corrected to the canonical, case-sensitive IANA name:

Europe/Amsterdam

A small test is added to ensure importing entsoe does not fail due to timezone resolution.

**Why**

With pandas 3.0+, timezone strings are resolved via Python’s standard-library zoneinfo module (PEP 615).
zoneinfo strictly enforces case-sensitive IANA timezone identifiers, and europe/amsterdam is invalid.

As a result, importing entsoe currently raises:
ZoneInfoNotFoundError: 'No time zone found with key europe/amsterdam'

This happens at import time, preventing any usage of the library in affected environments.

Previously, this issue was masked because pandas ≤2.x often returned pytz timezones, which are more lenient.

**Changes**

- Replace europe/amsterdam → Europe/Amsterdam

- Added a small unit test ensuring:
  - the timezone key is resolvable via zoneinfo
  - importing entsoe does not raise due to timezone resolution

**Impact**

- Compatible with pandas 2.x and 3.x
- Compatible with zoneinfo + tzdata
- No behavior change other than fixing import failures