### PR TITLE
fix: timezone capitalization for Europe/Amsterdam for pandas 3.0

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1190,7 +1190,7 @@ class EntsoePandasClient(EntsoeRawClient):
         if dayahead:
             # This function should only return SDAC net positions for day ahead, which have a fixed defined resolution
             # before 2025-10-01 its 60min, after 15min
-            # this is aligned on businessday in timezone europe/amsterdam
+            # this is aligned on businessday in timezone Europe/Amsterdam
             # some zones already publish in different resolution.
             # for secondary auctions published on entsoe, use the query_day_ahead_prices_local function
             if series.index.max() < QUARTER_MTU_SDAC_GOLIVE:
@@ -1290,11 +1290,11 @@ class EntsoePandasClient(EntsoeRawClient):
 
         # This function should only return SDAC prices, which have a fixed defined resolution
         # before 2025-10-01 its 60min, after 15min
-        # this is aligned on businessday in timezone europe/amsterdam
+        # this is aligned on businessday in timezone Europe/Amsterdam
         # some zones already publish in different resolution.
         # for secondary auctions published on entsoe, use the query_day_ahead_prices_local function
 
-        series = pd.concat([x for x in series_all.values() if len(x) > 0]).sort_index().tz_convert('europe/amsterdam')
+        series = pd.concat([x for x in series_all.values() if len(x) > 0]).sort_index().tz_convert('Europe/Amsterdam')
         if len(series) == 0:
             raise NoMatchingDataError
         if series.index.max() < QUARTER_MTU_SDAC_GOLIVE:

--- a/entsoe/files/decorators.py
+++ b/entsoe/files/decorators.py
@@ -7,7 +7,7 @@ def check_expired(func):
     def check_expired_wrapper(*args, **kwargs):
         self = args[0]
 
-        if pd.Timestamp.now(tz='europe/amsterdam') >= self.expire:
+        if pd.Timestamp.now(tz='Europe/Amsterdam') >= self.expire:
             self._update_token()
 
         return func(*args, **kwargs)

--- a/entsoe/files/entsoe_files.py
+++ b/entsoe/files/entsoe_files.py
@@ -55,7 +55,7 @@ class EntsoeFileClient:
         )
         r.raise_for_status()
         data = r.json()
-        self.expire = pd.Timestamp.now(tz='europe/amsterdam') + pd.Timedelta(seconds=data['expires_in'])
+        self.expire = pd.Timestamp.now(tz='Europe/Amsterdam') + pd.Timedelta(seconds=data['expires_in'])
         self.access_token = data['access_token']
 
     @check_expired


### PR DESCRIPTION
One place was already fixed in #505, but a few more were apparently forgotten.