### PR TITLE
Fix incorrect voltage tag in capacity parser

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -813,7 +813,7 @@ def _parse_installed_capacity_per_plant(soup):
                     'Bidding Zone': 'inbiddingzone_domain.mrid',
                     # 'Status': 'businesstype',
                     'Voltage Connection Level [kV]':
-                        'voltage_powersystemresources.highvoltagelimit'}
+                        'production_powersystemresources.highvoltagelimit'}
     series = pd.Series(extract_vals).apply(lambda v: soup.find(v).text)
 
     # extract only first point


### PR DESCRIPTION
When calling query_installed_generation_capacity_per_unit, parsing fails due to an incorrect XML tag name in _parse_installed_capacity_per_plant.

In parsers.py, the parser uses the tag:

`voltage_powersystemresources.highvoltagelimit`

However, recent ENTSO-E XML responses contain:

`production_PowerSystemResources.highVoltageLimit`

I renamed the tag. 

Minimal Test Case:

```
from entsoe import EntsoePandasClient
import pandas as pd

client = EntsoePandasClient(api_key="YOUR_API_KEY")

df = client.query_installed_generation_capacity_per_unit(
    "NL",
    start=pd.Timestamp("2025-01-01"),
    end=pd.Timestamp("2026-01-01"),
)

print(df["Voltage Connection Level [kV]"])
```
