### PR TITLE
this adds the start period to capacity per plant

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -800,6 +800,8 @@ def _parse_generation_timeseries(soup, per_plant: bool = False, include_eic: boo
 
 def _parse_installed_capacity_per_plant(soup):
     """
+    Parses the installed capacities for a timeseries from _extract_timeseries 
+
     Parameters
     ----------
     soup : bs4.element.tag
@@ -816,9 +818,12 @@ def _parse_installed_capacity_per_plant(soup):
                         'voltage_powersystemresources.highvoltagelimit'}
     series = pd.Series(extract_vals).apply(lambda v: soup.find(v).text)
 
+    period = soup.find('period')
+    series["Start"] = pd.to_datetime(period.find('timeinterval.start').text)
+
     # extract only first point
     series['Installed Capacity [MW]'] = \
-        soup.find_all('point')[0].find('quantity').text
+        period.find_all('point')[0].find('quantity').text
 
     series.name = soup.find('registeredresource.mrid').text
 


### PR DESCRIPTION
Also requires #514 to work.

fixes #294

This way

```
start = pd.Timestamp("20150102", tz="Europe/Berlin")
end = pd.Timestamp("20250201", tz="Europe/Berlin")
df = client.query_installed_generation_capacity_per_unit("DE_LU", start=start, end=end)
```
shows all columns correctly with availability per year