### PR TITLE
Fix DE_LU and AT day-ahead prices: update SDAC sequence from 1 to 2

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -1284,7 +1284,7 @@ class EntsoePandasClient(EntsoeRawClient):
             start=start,
             end=end,
             offset=offset,
-            sequence=1 if area.name in ['DE_LU', 'AT'] else None
+            sequence=2 if area.name in ['DE_LU', 'AT'] else None
         )
         series_all = parse_prices(text)
 


### PR DESCRIPTION
ENTSO-E changed the SDAC (Single Day-Ahead Coupling) prices for DE_LU and AT from classificationSequence position 1 to position 2.

The current hardcoded `sequence=1` in `_query_day_ahead_prices` causes `NoMatchingDataError` for these areas since no data is published at position 1 anymore.