### PR TITLE
feat: Add support for parsing ZIP archives of procured balancing capacity

### DIFF
--- a/entsoe/entsoe.py
+++ b/entsoe/entsoe.py
@@ -16,7 +16,7 @@ from .parsers import parse_prices, parse_loads, parse_generation, \
     parse_installed_capacity_per_plant, parse_crossborder_flows, \
     parse_unavailabilities, parse_contracted_reserve, parse_contracted_reserve_zip, \
     parse_imbalance_prices_zip, parse_imbalance_volumes_zip, parse_netpositions, \
-    parse_procured_balancing_capacity, parse_water_hydro, parse_aggregated_bids, \
+    parse_procured_balancing_capacity_zip, parse_water_hydro, parse_aggregated_bids, \
     parse_activated_balancing_energy_prices, parse_offshore_unavailability, parse_imbalance_volumes
 from .decorators import retry, paginated, year_limited, day_limited, documents_limited
 import warnings
@@ -884,7 +884,7 @@ class EntsoeRawClient:
     def query_procured_balancing_capacity(
             self, country_code: Union[Area, str], start: pd.Timestamp,
             end: pd.Timestamp, process_type: str,
-            type_marketagreement_type: Optional[str] = None) -> bytes:
+            type_marketagreement_type: Optional[str] = None, offset: int = 0) -> bytes:
         """
         Parameters
         ----------
@@ -895,6 +895,8 @@ class EntsoeRawClient:
             A51 ... aFRR; A47 ... mFRR
         type_marketagreement_type : str
             type of contract (see mappings.MARKETAGREEMENTTYPE)
+        offset: int
+            offset for querying more than 100 documents
 
         Returns
         -------
@@ -907,7 +909,8 @@ class EntsoeRawClient:
         params = {
             'documentType': 'A15',
             'area_Domain': area.code,
-            'processType': process_type
+            'processType': process_type,
+            "offset": offset,
         }
         if type_marketagreement_type:
             params.update({'type_MarketAgreement.Type': type_marketagreement_type})
@@ -2050,13 +2053,15 @@ class EntsoePandasClient(EntsoeRawClient):
 
     @year_limited
     @paginated
+    @documents_limited(100)
     def query_procured_balancing_capacity(
             self,
             country_code: Union[Area, str],
             process_type: str,
             start: pd.Timestamp,
             end: pd.Timestamp,
-            type_marketagreement_type: Optional[str] = None) -> bytes:
+            type_marketagreement_type: Optional[str] = None,
+            offset: int = 0) -> pd.DataFrame:
         """
         Parameters
         ----------
@@ -2067,16 +2072,20 @@ class EntsoePandasClient(EntsoeRawClient):
         end : pd.Timestamp
         type_marketagreement_type : str
             type of contract (see mappings.MARKETAGREEMENTTYPE)
+        offset: int
+            offset for querying more than 100 documents
 
         Returns
         -------
         pd.DataFrame
         """
         area = lookup_area(country_code)
-        text = super(EntsoePandasClient, self).query_procured_balancing_capacity(
+        zip_contents = super(EntsoePandasClient, self).query_procured_balancing_capacity(
             country_code=area, start=start, end=end,
-            process_type=process_type, type_marketagreement_type=type_marketagreement_type)
-        df = parse_procured_balancing_capacity(text, area.tz)
+            process_type=process_type, type_marketagreement_type=type_marketagreement_type,
+            offset=offset
+        )
+        df = parse_procured_balancing_capacity_zip(zip_contents, area.tz)
         df = df.tz_convert(area.tz)
         df = df.truncate(before=start, after=end)
         return df

--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -312,6 +312,35 @@ def parse_imbalance_volumes(xml_text, include_resolution=False):
     return df
 
 
+def parse_procured_balancing_capacity_zip(zip_contents: bytes, tz: str) -> pd.DataFrame:
+    """
+    Parameters
+    ----------
+    zip_contents : bytes
+        ZIP archive containing XML files
+    tz : str
+        Timezone for datetime parsing
+
+    Returns
+    -------
+    pd.DataFrame
+    """
+
+    def gen_frames(archive):
+        with zipfile.ZipFile(BytesIO(archive), 'r') as arc:
+            for f in arc.infolist():
+                if f.filename.endswith('xml'):
+                    frame = parse_procured_balancing_capacity(
+                        xml_text=arc.read(f), tz=tz
+                    )
+                    yield frame
+
+    frames = gen_frames(zip_contents)
+    df = pd.concat(frames)
+    df.sort_index(inplace=True)
+    return df
+
+
 def parse_procured_balancing_capacity(xml_text, tz):
     """
     Parameters
@@ -409,19 +438,19 @@ def _parse_procured_balancing_capacity(soup, tz):
     }
 
     flow_direction = direction[soup.find('flowdirection.direction').text]
-    period = soup.find('period')
-    start = pd.to_datetime(period.find('timeinterval').find('start').text)
-    end = pd.to_datetime(period.find('timeinterval').find('end').text)
-    resolution = _resolution_to_timedelta(period.find('resolution').text)
-    tx = pd.date_range(start=start, end=end, freq=resolution, inclusive='left')
-    points = period.find_all('point')
-    df = pd.DataFrame(index=tx, columns=['Price', 'Volume'])
-
-    for dt, point in zip(tx, points):
-        df.loc[dt, 'Price'] = float(point.find('procurement_price.amount').text)
-        df.loc[dt, 'Volume'] = float(point.find('quantity').text)
-
     mr_id = int(soup.find('mrid').text)
+
+    df = pd.DataFrame(
+        {
+            'Price': _parse_timeseries_generic(
+                soup, label='procurement_price.amount', merge_series=True
+            ),
+            'Volume': _parse_timeseries_generic(
+                soup, label='quantity', merge_series=True
+            )
+        }
+    )
+
     df.columns = pd.MultiIndex.from_product(
         [[flow_direction], [mr_id], df.columns],
         names=('direction', 'mrid', 'unit')


### PR DESCRIPTION
Fixes method for querying procured balancing energy after the corresponding ENTSO-E endpoint switched to returning ZIP files (instead of XMLs).

Fixes #472 and #473. Potentially also #511.