### PR TITLE
Add offline unit tests for parsers (no API key required)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""
+Shared pytest fixtures for offline parser tests.
+
+The XML files in tests/fixtures/ are synthetic — constructed by reading
+the parser code and producing minimal documents that exercise the tag
+structures the parsers expect. They are not real ENTSO-E API responses.
+"""
+from pathlib import Path
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def load_fixture():
+    """Return a callable that loads a fixture file as a string."""
+    def _load(name: str) -> str:
+        return (FIXTURES_DIR / name).read_text(encoding="utf-8")
+    return _load

--- a/tests/fixtures/a03_gaps.xml
+++ b/tests/fixtures/a03_gaps.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic fixture for _parse_timeseries_generic with curvetype A03.
+
+  Per the ENTSO-E curve-type spec, A03 documents may omit positions when
+  the value repeats. Positions 2 and 4 are absent here and must be
+  forward-filled from positions 1 and 3.
+-->
+<doc>
+  <timeseries>
+    <curvetype>A03</curvetype>
+    <period>
+      <timeinterval>
+        <start>2026-01-01T00:00Z</start>
+        <end>2026-01-01T04:00Z</end>
+      </timeinterval>
+      <resolution>PT60M</resolution>
+      <point><position>1</position><quantity>100.0</quantity></point>
+      <point><position>3</position><quantity>200.0</quantity></point>
+    </period>
+  </timeseries>
+</doc>

--- a/tests/fixtures/crossborder_flows.xml
+++ b/tests/fixtures/crossborder_flows.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic fixture for parse_crossborder_flows.
+
+  Two periods within one timeseries at PT60M. The parser routes through
+  _parse_timeseries_generic_whole which concatenates everything into a
+  single flat series.
+-->
+<publication_marketdocument>
+  <timeseries>
+    <curvetype>A01</curvetype>
+    <period>
+      <timeinterval>
+        <start>2026-01-01T00:00Z</start>
+        <end>2026-01-01T02:00Z</end>
+      </timeinterval>
+      <resolution>PT60M</resolution>
+      <point><position>1</position><quantity>1200.0</quantity></point>
+      <point><position>2</position><quantity>1300.0</quantity></point>
+    </period>
+    <period>
+      <timeinterval>
+        <start>2026-01-01T02:00Z</start>
+        <end>2026-01-01T04:00Z</end>
+      </timeinterval>
+      <resolution>PT60M</resolution>
+      <point><position>1</position><quantity>1400.0</quantity></point>
+      <point><position>2</position><quantity>1500.0</quantity></point>
+    </period>
+  </timeseries>
+</publication_marketdocument>

--- a/tests/fixtures/generation.xml
+++ b/tests/fixtures/generation.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic fixture for parse_generation (default: per_plant=False, nett=False).
+
+  Two timeseries, both with inbiddingzone_domain.mrid (-> 'Actual Aggregated'),
+  different psrtypes. Because both share the same last-level name the
+  redundant 'Actual Aggregated' level is dropped by
+  _calc_nett_and_drop_redundant_columns, leaving flat columns named by
+  production type.
+-->
+<gl_marketdocument>
+  <timeseries>
+    <inbiddingzone_domain.mrid>10YBE----------2</inbiddingzone_domain.mrid>
+    <mktpsrtype><psrtype>B14</psrtype></mktpsrtype>
+    <curvetype>A01</curvetype>
+    <period>
+      <timeinterval>
+        <start>2026-01-01T00:00Z</start>
+        <end>2026-01-01T03:00Z</end>
+      </timeinterval>
+      <resolution>PT60M</resolution>
+      <point><position>1</position><quantity>900.0</quantity></point>
+      <point><position>2</position><quantity>910.0</quantity></point>
+      <point><position>3</position><quantity>920.0</quantity></point>
+    </period>
+  </timeseries>
+  <timeseries>
+    <inbiddingzone_domain.mrid>10YBE----------2</inbiddingzone_domain.mrid>
+    <mktpsrtype><psrtype>B16</psrtype></mktpsrtype>
+    <curvetype>A01</curvetype>
+    <period>
+      <timeinterval>
+        <start>2026-01-01T00:00Z</start>
+        <end>2026-01-01T03:00Z</end>
+      </timeinterval>
+      <resolution>PT60M</resolution>
+      <point><position>1</position><quantity>150.0</quantity></point>
+      <point><position>2</position><quantity>200.0</quantity></point>
+      <point><position>3</position><quantity>180.0</quantity></point>
+    </period>
+  </timeseries>
+</gl_marketdocument>

--- a/tests/fixtures/generation_mixed.xml
+++ b/tests/fixtures/generation_mixed.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic fixture for parse_generation with mixed in/out direction.
+
+  Hydro Pumped Storage (B10) reported once with inbiddingzone (generation,
+  'Actual Aggregated') and once with outbiddingzone (charging, 'Actual
+  Consumption'). This is the case where the MultiIndex is *not*
+  collapsed and where nett=True must compute Aggregated - Consumption.
+-->
+<gl_marketdocument>
+  <timeseries>
+    <inbiddingzone_domain.mrid>10YBE----------2</inbiddingzone_domain.mrid>
+    <mktpsrtype><psrtype>B10</psrtype></mktpsrtype>
+    <curvetype>A01</curvetype>
+    <period>
+      <timeinterval>
+        <start>2026-01-01T00:00Z</start>
+        <end>2026-01-01T02:00Z</end>
+      </timeinterval>
+      <resolution>PT60M</resolution>
+      <point><position>1</position><quantity>300.0</quantity></point>
+      <point><position>2</position><quantity>310.0</quantity></point>
+    </period>
+  </timeseries>
+  <timeseries>
+    <outbiddingzone_domain.mrid>10YBE----------2</outbiddingzone_domain.mrid>
+    <mktpsrtype><psrtype>B10</psrtype></mktpsrtype>
+    <curvetype>A01</curvetype>
+    <period>
+      <timeinterval>
+        <start>2026-01-01T00:00Z</start>
+        <end>2026-01-01T02:00Z</end>
+      </timeinterval>
+      <resolution>PT60M</resolution>
+      <point><position>1</position><quantity>50.0</quantity></point>
+      <point><position>2</position><quantity>60.0</quantity></point>
+    </period>
+  </timeseries>
+</gl_marketdocument>

--- a/tests/fixtures/installed_capacity_per_plant.xml
+++ b/tests/fixtures/installed_capacity_per_plant.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic fixture for parse_installed_capacity_per_plant.
+
+  The tag `production_powersystemresources.highvoltagelimit` is the one
+  ENTSO-E silently renamed, triggering issue #513 / PR #514. If the
+  schema drifts again this test fails loudly instead of users hitting an
+  AttributeError at runtime.
+
+  psrtype codes (B14=Nuclear, B16=Solar, B19=Wind Onshore) are resolved
+  through PSRTYPE_MAPPINGS by the outer parser.
+-->
+<gl_marketdocument>
+  <timeseries>
+    <registeredresource.mrid>22WPLANT-NUKE-01</registeredresource.mrid>
+    <registeredresource.name>Test Nuclear Plant</registeredresource.name>
+    <psrtype>B14</psrtype>
+    <inbiddingzone_domain.mrid>10YBE----------2</inbiddingzone_domain.mrid>
+    <production_powersystemresources.highvoltagelimit>380</production_powersystemresources.highvoltagelimit>
+    <period>
+      <timeinterval.start>2026-01-01T00:00Z</timeinterval.start>
+      <point><position>1</position><quantity>1000.0</quantity></point>
+    </period>
+  </timeseries>
+  <timeseries>
+    <registeredresource.mrid>22WPLANT-SOLR-02</registeredresource.mrid>
+    <registeredresource.name>Test Solar Farm</registeredresource.name>
+    <psrtype>B16</psrtype>
+    <inbiddingzone_domain.mrid>10YBE----------2</inbiddingzone_domain.mrid>
+    <production_powersystemresources.highvoltagelimit>150</production_powersystemresources.highvoltagelimit>
+    <period>
+      <timeinterval.start>2026-01-01T00:00Z</timeinterval.start>
+      <point><position>1</position><quantity>250.0</quantity></point>
+    </period>
+  </timeseries>
+  <timeseries>
+    <registeredresource.mrid>22WPLANT-WIND-03</registeredresource.mrid>
+    <registeredresource.name>Test Wind Park</registeredresource.name>
+    <psrtype>B19</psrtype>
+    <inbiddingzone_domain.mrid>10YBE----------2</inbiddingzone_domain.mrid>
+    <production_powersystemresources.highvoltagelimit>220</production_powersystemresources.highvoltagelimit>
+    <period>
+      <timeinterval.start>2026-01-01T00:00Z</timeinterval.start>
+      <point><position>1</position><quantity>80.0</quantity></point>
+    </period>
+  </timeseries>
+</gl_marketdocument>

--- a/tests/fixtures/loads.xml
+++ b/tests/fixtures/loads.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic fixture for parse_loads (process_type A01 / A16 path).
+
+  Single timeseries, PT60M, three points, quantity label.
+  A01 -> 'Forecasted Load' column, A16 -> 'Actual Load' column.
+-->
+<gl_marketdocument>
+  <timeseries>
+    <curvetype>A01</curvetype>
+    <period>
+      <timeinterval>
+        <start>2026-01-01T00:00Z</start>
+        <end>2026-01-01T03:00Z</end>
+      </timeinterval>
+      <resolution>PT60M</resolution>
+      <point><position>1</position><quantity>5000.0</quantity></point>
+      <point><position>2</position><quantity>5100.0</quantity></point>
+      <point><position>3</position><quantity>5200.0</quantity></point>
+    </period>
+  </timeseries>
+</gl_marketdocument>

--- a/tests/fixtures/prices.xml
+++ b/tests/fixtures/prices.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic fixture for parse_prices / _parse_timeseries_generic(label='price.amount').
+
+  Two timeseries at PT60M resolution across consecutive intervals, so the
+  parser must concatenate them into a single 4-point series under the
+  '60min' key. The '15min' and '30min' keys should come back empty.
+
+  curvetype A01 = sequential fixed block (no gap handling).
+-->
+<publication_marketdocument>
+  <timeseries>
+    <curvetype>A01</curvetype>
+    <period>
+      <timeinterval>
+        <start>2026-01-01T00:00Z</start>
+        <end>2026-01-01T02:00Z</end>
+      </timeinterval>
+      <resolution>PT60M</resolution>
+      <point><position>1</position><price.amount>50.25</price.amount></point>
+      <point><position>2</position><price.amount>48.75</price.amount></point>
+    </period>
+  </timeseries>
+  <timeseries>
+    <curvetype>A01</curvetype>
+    <period>
+      <timeinterval>
+        <start>2026-01-01T02:00Z</start>
+        <end>2026-01-01T04:00Z</end>
+      </timeinterval>
+      <resolution>PT60M</resolution>
+      <point><position>1</position><price.amount>52.00</price.amount></point>
+      <point><position>2</position><price.amount>55.10</price.amount></point>
+    </period>
+  </timeseries>
+</publication_marketdocument>

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,190 @@
+"""
+Offline unit tests for entsoe.parsers.
+
+Covers five public parsers against synthetic XML fixtures. The intent is
+to lock in output *shape* (types, columns, index, lengths) plus a
+handful of representative values, so that upstream schema drift or
+refactors that change behaviour fail loudly and locally rather than at
+runtime against the live API.
+
+Fixtures live in tests/fixtures/ and are documented inline.
+"""
+import pandas as pd
+import pytest
+
+from entsoe.parsers import (
+    parse_crossborder_flows,
+    parse_generation,
+    parse_installed_capacity_per_plant,
+    parse_loads,
+    parse_prices,
+)
+
+
+# --- parse_prices --------------------------------------------------------
+
+def test_parse_prices_shape(load_fixture):
+    xml = load_fixture("prices.xml")
+    result = parse_prices(xml)
+
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {"15min", "30min", "60min"}
+    assert all(isinstance(s, pd.Series) for s in result.values())
+
+
+def test_parse_prices_concatenates_timeseries(load_fixture):
+    """Two PT60M timeseries should concatenate into one sorted series."""
+    xml = load_fixture("prices.xml")
+    result = parse_prices(xml)
+
+    s60 = result["60min"]
+    assert len(s60) == 4
+    assert s60.dtype == float
+    assert s60.index.is_monotonic_increasing
+    assert s60.iloc[0] == 50.25
+    assert s60.iloc[-1] == 55.10
+    # buckets for resolutions not present in the fixture stay empty
+    assert len(result["15min"]) == 0
+    assert len(result["30min"]) == 0
+
+
+# --- parse_loads ---------------------------------------------------------
+
+def test_parse_loads_a01_forecasted(load_fixture):
+    xml = load_fixture("loads.xml")
+    result = parse_loads(xml, process_type="A01")
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ["Forecasted Load"]
+    assert len(result) == 3
+    assert result["Forecasted Load"].iloc[0] == 5000.0
+    assert result["Forecasted Load"].iloc[2] == 5200.0
+    assert result.index.is_monotonic_increasing
+
+
+def test_parse_loads_a16_actual(load_fixture):
+    """A16 uses the same parse path as A01 but labels the column differently."""
+    xml = load_fixture("loads.xml")
+    result = parse_loads(xml, process_type="A16")
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ["Actual Load"]
+    assert len(result) == 3
+    assert result["Actual Load"].iloc[1] == 5100.0
+
+
+# --- parse_crossborder_flows ---------------------------------------------
+
+def test_parse_crossborder_flows(load_fixture):
+    xml = load_fixture("crossborder_flows.xml")
+    result = parse_crossborder_flows(xml)
+
+    assert isinstance(result, pd.Series)
+    assert result.dtype == float
+    # One timeseries with two periods of two points each -> 4 rows.
+    assert len(result) == 4
+    assert result.index.is_monotonic_increasing
+    assert result.iloc[0] == 1200.0
+    assert result.iloc[-1] == 1500.0
+
+
+# --- parse_installed_capacity_per_plant ----------------------------------
+# This parser is the one most sensitive to ENTSO-E schema drift: the
+# tag names it reads (registeredresource.*, production_powersystemresources.*)
+# are looked up literally, and issue #513 -> PR #514 was exactly a silent
+# tag rename upstream. The fixture pins the set of tags the parser
+# currently requires.
+
+EXPECTED_CAPACITY_COLUMNS = [
+    "Name",
+    "Production Type",
+    "Bidding Zone",
+    "Voltage Connection Level [kV]",
+    "Start",
+    "Installed Capacity [MW]",
+]
+
+
+def test_parse_installed_capacity_per_plant_shape(load_fixture):
+    xml = load_fixture("installed_capacity_per_plant.xml")
+    result = parse_installed_capacity_per_plant(xml)
+
+    assert isinstance(result, pd.DataFrame)
+    # One row per plant, indexed by registeredresource.mrid.
+    assert result.shape == (3, 6)
+    assert list(result.columns) == EXPECTED_CAPACITY_COLUMNS
+    assert set(result.index) == {
+        "22WPLANT-NUKE-01",
+        "22WPLANT-SOLR-02",
+        "22WPLANT-WIND-03",
+    }
+
+
+def test_parse_installed_capacity_per_plant_values(load_fixture):
+    xml = load_fixture("installed_capacity_per_plant.xml")
+    result = parse_installed_capacity_per_plant(xml)
+
+    nuke = result.loc["22WPLANT-NUKE-01"]
+    assert nuke["Name"] == "Test Nuclear Plant"
+    assert nuke["Production Type"] == "Nuclear"  # B14 -> PSRTYPE_MAPPINGS
+    assert nuke["Voltage Connection Level [kV]"] == "380"
+    assert nuke["Installed Capacity [MW]"] == "1000.0"
+    assert nuke["Start"] == pd.Timestamp("2026-01-01T00:00Z")
+
+    solar = result.loc["22WPLANT-SOLR-02"]
+    assert solar["Production Type"] == "Solar"  # B16
+    assert solar["Installed Capacity [MW]"] == "250.0"
+
+    wind = result.loc["22WPLANT-WIND-03"]
+    assert wind["Production Type"] == "Wind Onshore"  # B19
+
+
+# --- parse_generation ----------------------------------------------------
+
+def test_parse_generation_drops_redundant_level(load_fixture):
+    """
+    When all timeseries share the same direction (inbiddingzone ->
+    'Actual Aggregated'), that last level is redundant and
+    _calc_nett_and_drop_redundant_columns drops it, leaving columns
+    named directly by production type.
+    """
+    xml = load_fixture("generation.xml")
+    result = parse_generation(xml)
+
+    assert isinstance(result, pd.DataFrame)
+    assert result.columns.nlevels == 1
+    assert set(result.columns) == {"Nuclear", "Solar"}
+    assert len(result) == 3
+    assert result["Nuclear"].iloc[0] == 900.0
+    assert result["Solar"].iloc[2] == 180.0
+
+
+def test_parse_generation_mixed_direction_keeps_multiindex(load_fixture):
+    """
+    When the same production type reports both inbiddingzone and
+    outbiddingzone timeseries, the parser must keep the 2-level
+    MultiIndex (type, metric) so callers can distinguish generation
+    from consumption.
+    """
+    xml = load_fixture("generation_mixed.xml")
+    result = parse_generation(xml)
+
+    assert isinstance(result, pd.DataFrame)
+    assert result.columns.nlevels == 2
+    cols = set(result.columns)
+    assert ("Hydro Pumped Storage", "Actual Aggregated") in cols
+    assert ("Hydro Pumped Storage", "Actual Consumption") in cols
+    assert result[("Hydro Pumped Storage", "Actual Aggregated")].iloc[0] == 300.0
+    assert result[("Hydro Pumped Storage", "Actual Consumption")].iloc[0] == 50.0
+
+
+def test_parse_generation_nett(load_fixture):
+    """nett=True collapses Aggregated - Consumption into a single column."""
+    xml = load_fixture("generation_mixed.xml")
+    result = parse_generation(xml, nett=True)
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ["Hydro Pumped Storage"]
+    # 300 - 50 = 250, 310 - 60 = 250
+    assert result["Hydro Pumped Storage"].iloc[0] == 250.0
+    assert result["Hydro Pumped Storage"].iloc[1] == 250.0

--- a/tests/test_series_parsers.py
+++ b/tests/test_series_parsers.py
@@ -1,0 +1,139 @@
+"""
+Offline unit tests for entsoe.series_parsers.
+
+These tests run without network access or API credentials. Fixtures in
+tests/fixtures/ are minimal synthetic XML documents constructed to match
+the tag structures the parsers expect — not real ENTSO-E responses.
+"""
+import bs4
+import pandas as pd
+import pytest
+
+from entsoe.series_parsers import (
+    _extract_timeseries,
+    _parse_datetimeindex,
+    _parse_timeseries_generic,
+    _resolution_to_timedelta,
+)
+
+
+# --- _resolution_to_timedelta --------------------------------------------
+# Issue #516 was an unknown resolution string hitting the hardcoded dict
+# and raising at runtime. Pinning every known key means schema additions
+# surface here first.
+
+@pytest.mark.parametrize(
+    "resolution,expected",
+    [
+        ("PT60M", "60min"),
+        ("P1Y", "12MS"),
+        ("PT15M", "15min"),
+        ("PT30M", "30min"),
+        ("P1D", "1D"),
+        ("P7D", "7D"),
+        ("P1M", "1MS"),
+        ("PT1M", "1min"),
+    ],
+)
+def test_resolution_to_timedelta_known(resolution, expected):
+    assert _resolution_to_timedelta(resolution) == expected
+
+
+def test_resolution_to_timedelta_unknown_raises():
+    with pytest.raises(NotImplementedError, match="PT4S"):
+        _resolution_to_timedelta("PT4S")
+
+
+# --- _extract_timeseries -------------------------------------------------
+
+def test_extract_timeseries_empty_string():
+    assert list(_extract_timeseries("")) == []
+
+
+def test_extract_timeseries_none():
+    assert list(_extract_timeseries(None)) == []
+
+
+def test_extract_timeseries_no_matches():
+    assert list(_extract_timeseries("<?xml?><doc><other/></doc>")) == []
+
+
+def test_extract_timeseries_yields_each_tag(load_fixture):
+    xml = load_fixture("prices.xml")
+    result = list(_extract_timeseries(xml))
+    assert len(result) == 2
+    assert all(isinstance(ts, bs4.element.Tag) for ts in result)
+    assert all(ts.name == "timeseries" for ts in result)
+
+
+# --- _parse_datetimeindex ------------------------------------------------
+
+def test_parse_datetimeindex_basic(load_fixture):
+    xml = load_fixture("loads.xml")
+    soup = next(_extract_timeseries(xml))
+
+    idx = _parse_datetimeindex(soup)
+
+    assert isinstance(idx, pd.DatetimeIndex)
+    assert len(idx) == 3  # inclusive='left': 00:00, 01:00, 02:00
+    assert idx[0] == pd.Timestamp("2026-01-01T00:00Z")
+    assert idx[-1] == pd.Timestamp("2026-01-01T02:00Z")
+    assert str(idx.tz) == "UTC"
+
+
+def test_parse_datetimeindex_tz_conversion(load_fixture):
+    xml = load_fixture("loads.xml")
+    soup = next(_extract_timeseries(xml))
+
+    idx = _parse_datetimeindex(soup, tz="Europe/Brussels")
+
+    # Final step of tz path converts back to UTC regardless of input tz.
+    assert str(idx.tz) == "UTC"
+    assert len(idx) == 3
+
+
+# --- _parse_timeseries_generic -------------------------------------------
+
+def test_parse_timeseries_generic_returns_freq_dict(load_fixture):
+    xml = load_fixture("loads.xml")
+    soup = next(_extract_timeseries(xml))
+
+    result = _parse_timeseries_generic(soup)
+
+    assert set(result.keys()) >= {"15min", "30min", "60min"}
+    assert result["15min"] is None
+    assert result["30min"] is None
+
+    s60 = result["60min"]
+    assert isinstance(s60, pd.Series)
+    assert len(s60) == 3
+    assert s60.dtype == float
+    assert list(s60.values) == [5000.0, 5100.0, 5200.0]
+
+
+def test_parse_timeseries_generic_merge_series(load_fixture):
+    xml = load_fixture("loads.xml")
+    soup = next(_extract_timeseries(xml))
+
+    result = _parse_timeseries_generic(soup, merge_series=True)
+
+    assert isinstance(result, pd.Series)
+    assert len(result) == 3
+    assert result.iloc[0] == 5000.0
+
+
+def test_parse_timeseries_generic_a03_forward_fills_gaps(load_fixture):
+    """
+    Curvetype A03 permits omitting a <point> when the value is unchanged
+    from the previous position. The parser must reindex onto the full
+    range and forward-fill.
+    """
+    xml = load_fixture("a03_gaps.xml")
+    soup = next(_extract_timeseries(xml))
+
+    result = _parse_timeseries_generic(soup, merge_series=True)
+
+    # Fixture gives positions 1 and 3 over a 4-hour window.
+    # Expected: [100, 100, 200, 200] after forward-fill.
+    assert len(result) == 4
+    assert list(result.values) == [100.0, 100.0, 200.0, 200.0]


### PR DESCRIPTION
This adds fixture-based unit tests for `parsers.py` and `series_parsers.py` that run offline — no ENTSO-E credentials, no network.

## Motivation

Several recent issues (#513 → #514, #516, #520, #522) trace back to parser behaviour: schema drift at ENTSO-E's end, edge-case inputs, shape mismatches. The existing `test_files.py` exercises the file client against the live API, but there isn't currently a fast, credential-free way to pin down what the XML parsers themselves expect.

These tests aim to make that class of change fail loudly and locally.

## What's added

**`tests/fixtures/`** — seven small synthetic XML documents (22–47 lines each). They're constructed by reading the parser code and producing minimal structures that exercise the relevant tags, so they stay readable and don't need regenerating from the API. Each has a comment explaining what it targets.

**`tests/test_series_parsers.py`** (18 tests)
- `_resolution_to_timedelta` — parametrised over all 8 known resolution keys + the `NotImplementedError` path for unknowns
- `_extract_timeseries` — empty / None / no-match / multi-match
- `_parse_datetimeindex` — length, bounds, tz handling
- `_parse_timeseries_generic` — freq-dict shape, `merge_series=True`, and the **A03 curvetype forward-fill** behaviour (positions omitted → repeat previous value)

**`tests/test_parsers.py`** (10 tests)
- `parse_prices` — concatenation across timeseries, empty buckets for absent resolutions
- `parse_loads` — A01 / A16 column naming
- `parse_crossborder_flows` — multi-period concatenation
- `parse_installed_capacity_per_plant` — shape, PSRTYPE mapping, value extraction. **This one pins the exact set of tag names the parser reads** (including `production_powersystemresources.highvoltagelimit`), so a repeat of #513 would fail here
- `parse_generation` — redundant-level drop, MultiIndex when in/out directions mix, `nett=True` arithmetic

## Running

```
pytest tests/test_series_parsers.py tests/test_parsers.py
```

28 tests, ~0.3 seconds, no network.

## What this doesn't do

- No source changes — purely additive.
- No CI config changes.
- Covers 5 of ~35 public parsers. If the approach looks right I'm happy to extend to the others in follow-ups.

---

*Drafted with AI assistance; I've reviewed and run everything locally. There's no pre-existing offline test pattern in the repo so I picked reasonable pytest defaults — very happy to restructure if you'd prefer something different.*
