### PR TITLE
Preserve EIC column level for single-unit generation_per_plant(include_eic=True)

### DIFF
--- a/entsoe/parsers.py
+++ b/entsoe/parsers.py
@@ -156,12 +156,13 @@ def parse_generation(
     df = pd.DataFrame.from_dict(all_series)
     df.sort_index(inplace=True)
 
-    df = _calc_nett_and_drop_redundant_columns(df, nett=nett)
+    df = _calc_nett_and_drop_redundant_columns(
+        df, nett=nett, drop_redundant=not include_eic)
     return df
 
 
 def _calc_nett_and_drop_redundant_columns(
-        df: pd.DataFrame, nett: bool) -> pd.DataFrame:
+        df: pd.DataFrame, nett: bool, drop_redundant: bool = True) -> pd.DataFrame:
     def _calc_nett(_df):
         try:
             if set(['Actual Aggregated']).issubset(_df):
@@ -178,8 +179,10 @@ def _calc_nett_and_drop_redundant_columns(
         return _new
 
     if hasattr(df.columns, 'levels'):
-        if len(df.columns.levels[-1]) == 1:
-            # Drop the extra header, if it is redundant
+        if drop_redundant and len(df.columns.levels[-1]) == 1:
+            # Drop the extra header, if it is redundant. Skipped when the innermost
+            # level is the include_eic level: a single-unit window has one eic, which
+            # would otherwise be discarded even though the eic is the join key.
             df = df.droplevel(axis=1, level=-1)
         elif nett:
             frames = []

--- a/tests/test_per_plant_eic.py
+++ b/tests/test_per_plant_eic.py
@@ -1,0 +1,59 @@
+"""Offline regression: per-plant generation must keep the EIC column level.
+
+`_calc_nett_and_drop_redundant_columns` drops the innermost column level when it
+has a single distinct value. With ``include_eic=True`` that innermost level is the
+EIC, so a window that returns a single generation unit silently loses the EIC -
+collapsing the per-plant columns from (plant, psr, metric, eic) to
+(plant, psr, metric). The EIC is the join key, so it must be preserved regardless of
+how many units the window returns.
+
+No network or API key required.
+"""
+import pandas as pd
+
+from entsoe.parsers import parse_generation
+
+
+# One generation unit, one metric -> the single-eic window that triggered the drop.
+SINGLE_UNIT = """
+<GL_MarketDocument>
+  <TimeSeries>
+    <mRID>1</mRID>
+    <businessType>A01</businessType>
+    <registeredResource.mRID codingScheme="A01">18WPVENT2--12342</registeredResource.mRID>
+    <MktPSRType>
+      <psrType>B04</psrType>
+      <PowerSystemResources>
+        <mRID codingScheme="A01">18WPVENT2-1234-P</mRID>
+        <name>PdV2</name>
+      </PowerSystemResources>
+    </MktPSRType>
+    <curveType>A03</curveType>
+    <Period>
+      <timeInterval><start>2026-06-11T22:00Z</start><end>2026-06-12T01:00Z</end></timeInterval>
+      <resolution>PT60M</resolution>
+      <Point><position>1</position><quantity>10</quantity></Point>
+      <Point><position>2</position><quantity>20</quantity></Point>
+      <Point><position>3</position><quantity>30</quantity></Point>
+    </Period>
+  </TimeSeries>
+</GL_MarketDocument>
+"""
+
+
+def test_single_unit_keeps_eic_level():
+    df = parse_generation(SINGLE_UNIT, per_plant=True, include_eic=True)
+    assert isinstance(df.columns, pd.MultiIndex)
+    # 4 levels: (plant, psr, metric, eic) - the eic level must survive.
+    assert df.columns.nlevels == 4, f"eic level dropped: {df.columns.tolist()}"
+    col = df.columns[0]
+    assert col[0] == "PdV2"
+    assert col[-1] == "18WPVENT2-1234-P"
+
+
+def test_single_unit_without_eic_still_drops_redundant_metric():
+    # Without include_eic the old redundant-drop behaviour is unchanged:
+    # (plant, psr, metric) with a single metric -> metric level dropped -> 2 levels.
+    df = parse_generation(SINGLE_UNIT, per_plant=True, include_eic=False)
+    assert df.columns.nlevels == 2
+    assert df.columns[0] == ("PdV2", "Fossil Gas")


### PR DESCRIPTION
## Problem

`parse_generation(..., per_plant=True, include_eic=True)` can silently drop the EIC
column level.

`_calc_nett_and_drop_redundant_columns` drops the innermost column level whenever it
has a single distinct value:

```python
if len(df.columns.levels[-1]) == 1:
    df = df.droplevel(axis=1, level=-1)
```

With `include_eic=True` the innermost level IS the EIC. A window that returns a single
generation unit therefore has exactly one EIC value, so the level looks "redundant" and
gets dropped, collapsing the per-plant columns from `(plant, psr, metric, eic)` to
`(plant, psr, metric)`. The EIC is the join key for per-plant data, so single-unit
windows lose it.

## Fix

Guard the redundant-drop with a `drop_redundant` flag, passed as `not include_eic` from
`parse_generation`:

- `include_eic=True`  -> `drop_redundant=False` -> EIC level always kept
- `include_eic=False` -> `drop_redundant=True`  -> unchanged behaviour

Backward compatible: the new parameter defaults to `True`, and the `include_eic=False`
path is unchanged.

## Test

Adds `tests/test_per_plant_eic.py`, a self-contained offline regression (embedded XML,
no network or API key):

- single-unit + `include_eic=True`  -> columns keep all 4 levels including the EIC
- single-unit + `include_eic=False` -> redundant metric level still dropped (2 levels)

## Scope

Refs #480. This fixes the single-unit EIC-drop specifically. The period / resolution
timestamp handling for the 15-min XML format also discussed in #480 is already present
on master (`series_parsers._parse_timeseries_generic` + `_resolution_to_timedelta`,
which maps `PT15M`), so this PR does not touch it; the remaining symptoms in that report
appear to stem from querying bidding zones (which return empty documents) rather than a
parser defect.